### PR TITLE
Added truncation support for the 'Highest Trait Floor' text on the list modal

### DIFF
--- a/packages/ui/src/modal/Stat.tsx
+++ b/packages/ui/src/modal/Stat.tsx
@@ -17,6 +17,7 @@ const Stat: FC<StatProps> = ({
 }) => (
   <Flex
     align="center"
+    justify="between"
     className="rk-stat-well"
     css={{
       backgroundColor: '$wellBackground',
@@ -26,9 +27,9 @@ const Stat: FC<StatProps> = ({
     }}
     {...props}
   >
-    <Text style="subtitle2" color="subtle" css={{ flex: 1, minWidth: '0' }}>
+    <Flex css={{ flex: 1, minWidth: '0', alignItems: 'center', gap: '$2', mr: '$1' }}>
       {label}
-    </Text>
+    </Flex>
     {asEth && !asWeth && <FormatEth amount={value} textStyle="subtitle2" />}
     {asWeth && !asEth && <FormatWEth amount={value} textStyle="subtitle2" />}
     {!asEth && !asWeth && (

--- a/packages/ui/src/modal/Stat.tsx
+++ b/packages/ui/src/modal/Stat.tsx
@@ -26,7 +26,7 @@ const Stat: FC<StatProps> = ({
     }}
     {...props}
   >
-    <Text style="subtitle2" color="subtle" css={{ flex: 1 }}>
+    <Text style="subtitle2" color="subtle" css={{ flex: 1, minWidth: '0' }}>
       {label}
     </Text>
     {asEth && !asWeth && <FormatEth amount={value} textStyle="subtitle2" />}

--- a/packages/ui/src/modal/bid/TokenStats.tsx
+++ b/packages/ui/src/modal/bid/TokenStats.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentPropsWithoutRef, FC } from 'react'
-import { Flex, Box, Grid } from '../../primitives'
+import { Flex, Box, Grid, Text } from '../../primitives'
 import TokenStatsHeader from './TokenStatsHeader'
 import Stat from '../Stat'
 import { useTokens, useCollections } from '../../hooks'
@@ -20,8 +20,15 @@ const TokenStats: FC<Props> = ({ token, collection, trait }) => {
     {
       id: 0,
       label: (
-        <Flex css={{ alignItems: 'center', gap: 8 }}>
-          <span>Creator Royalties</span>
+        <>
+          <Text
+            style="subtitle2"
+            color="subtle"
+            css={{ minWidth: '0' }}
+            ellipsify
+          >
+            Creator Royalties
+          </Text>
           <InfoTooltip
             side="right"
             width={200}
@@ -29,13 +36,22 @@ const TokenStats: FC<Props> = ({ token, collection, trait }) => {
               'A fee on every order that goes to the collection creator.'
             }
           />
-        </Flex>
+        </>
       ),
       value: (collection?.royalties?.bps || 0) * 0.01 + '%',
     },
     {
       id: 1,
-      label: 'Highest Offer',
+      label: (
+        <Text
+          style="subtitle2"
+          color="subtle"
+          css={{ minWidth: '0' }}
+          ellipsify
+        >
+          Highest Offer
+        </Text>
+      ),
       value: token
         ? token.market?.topBid?.price?.amount?.native || null
         : collection?.topBid?.price?.amount?.native || null,
@@ -46,14 +62,32 @@ const TokenStats: FC<Props> = ({ token, collection, trait }) => {
   if (token) {
     stats.push({
       id: 2,
-      label: 'List Price',
+      label: (
+        <Text
+          style="subtitle2"
+          color="subtle"
+          css={{ minWidth: '0' }}
+          ellipsify
+        >
+          List Price
+        </Text>
+      ),
       value: token.market?.floorAsk?.price?.amount?.native || 0,
       asEth: true,
     })
   } else if (!token && collection) {
     stats.push({
       id: 2,
-      label: 'Floor',
+      label: (
+        <Text
+          style="subtitle2"
+          color="subtle"
+          css={{ minWidth: '0' }}
+          ellipsify
+        >
+          Floor
+        </Text>
+      ),
       value: collection?.floorAsk?.price?.amount?.native || 0,
       asEth: true,
     })
@@ -72,7 +106,7 @@ const TokenStats: FC<Props> = ({ token, collection, trait }) => {
       }}
     >
       <TokenStatsHeader collection={collection} token={token} />
-      <Grid css={{ flex: 1, alignContent: 'start' }}>
+      <Grid css={{ flex: 1, alignContent: 'start', width: '100%', gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' }}>
         <SelectedAttribute
           attributeKey={trait?.key}
           attributeValue={trait?.value}

--- a/packages/ui/src/modal/list/TokenStats.tsx
+++ b/packages/ui/src/modal/list/TokenStats.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Flex, Box } from '../../primitives'
+import { Flex, Box, Text } from '../../primitives'
 import Token from './Token'
 import Stat from '../Stat'
 import { useTokens, useCollections } from '../../hooks'
@@ -74,8 +74,15 @@ const TokenStats: FC<Props> = ({ token, collection }) => {
           {
             id: 3,
             label: (
-              <Flex css={{ alignItems: 'center', gap: '$2', mr: '$1' }}>
-                <span>Highest Trait Floor</span>
+              <Flex css={{ alignItems: 'center', gap: '$2', mr: '$1', minWidth: '0' }}>
+                <Text
+                  style="subtitle2"
+                  color="subtle"
+                  css={{ minWidth: '0' }}
+                  ellipsify
+                >
+                  Highest Trait Floor
+                </Text>
                 <InfoTooltip
                   side="right"
                   width={200}

--- a/packages/ui/src/modal/list/TokenStats.tsx
+++ b/packages/ui/src/modal/list/TokenStats.tsx
@@ -13,11 +13,11 @@ type Props = {
 const TokenStats: FC<Props> = ({ token, collection }) => {
   let attributeFloor = token?.token?.attributes
     ? Math.max(
-        ...token.token.attributes.map((attr: any) =>
-          Number(attr.floorAskPrice)
-        ),
-        0
-      )
+      ...token.token.attributes.map((attr: any) =>
+        Number(attr.floorAskPrice)
+      ),
+      0
+    )
     : 0
   return (
     <Flex
@@ -46,35 +46,60 @@ const TokenStats: FC<Props> = ({ token, collection }) => {
           {
             id: 0,
             label: (
-              <Flex css={{ alignItems: 'center', gap: '$2', mr: '$1' }}>
-                <span>Creator Royalties</span>
-                <InfoTooltip
-                  side="right"
-                  width={200}
-                  content={
-                    'A fee on every order that goes to the collection creator.'
-                  }
-                />
-              </Flex>
+                <>
+                  <Text
+                    style="subtitle2"
+                    color="subtle"
+                    css={{ minWidth: '0' }}
+                    ellipsify
+                  >
+                    Creator Royalties
+                  </Text>
+                  <InfoTooltip
+                    side="right"
+                    width={200}
+                    content={
+                      'A fee on every order that goes to the collection creator.'
+                    }
+                  />
+                </>
             ),
             value: (collection?.royalties?.bps || 0) * 0.01 + '%',
           },
           {
             id: 1,
-            label: 'Last Sale',
+            label: (
+                <Text
+                  style="subtitle2"
+                  color="subtle"
+                  css={{ minWidth: '0' }}
+                  ellipsify
+                >
+                  Last Sale
+                </Text>
+            ),
             value: token?.token?.lastSell?.value || null,
             asEth: true,
           },
           {
             id: 2,
-            label: 'Collection Floor',
+            label: (
+                <Text
+                  style="subtitle2"
+                  color="subtle"
+                  css={{ minWidth: '0' }}
+                  ellipsify
+                >
+                  Collection Floor
+                </Text>
+            ),
             value: collection?.floorAsk?.price?.amount?.native || 0,
             asEth: true,
           },
           {
             id: 3,
             label: (
-              <Flex css={{ alignItems: 'center', gap: '$2', mr: '$1', minWidth: '0' }}>
+              <>
                 <Text
                   style="subtitle2"
                   color="subtle"
@@ -90,7 +115,7 @@ const TokenStats: FC<Props> = ({ token, collection }) => {
                     'The floor price of the most valuable trait of a token.'
                   }
                 />
-              </Flex>
+              </>
             ),
             value:
               attributeFloor ||


### PR DESCRIPTION
Before:
<img width="402" alt="image" src="https://user-images.githubusercontent.com/41527174/196553754-6a91a911-2f08-4ce8-8fd1-2d70fb6ba85a.png">


After:
<img width="205" alt="image" src="https://user-images.githubusercontent.com/41527174/196553711-09e8e376-3541-4aba-ae05-86a756e480ca.png">

