### PR TITLE
Convert bps fee to wei price when buying

### DIFF
--- a/demo/pages/_app.tsx
+++ b/demo/pages/_app.tsx
@@ -81,8 +81,6 @@ const AppWrapper = ({ children }) => {
         apiKey: API_KEY,
         marketplaceFee: FEE,
         marketplaceFeeRecipient: FEE_RECIPIENT,
-        referralFee: REFERRAL_FEE,
-        referralFeeRecipient: REFERRAL_FEE_RECIPIENT,
         source: SOURCE,
         normalizeRoyalties: NORMALIZE_ROYALTIES,
       }}

--- a/packages/client/src/actions/buyToken.ts
+++ b/packages/client/src/actions/buyToken.ts
@@ -83,16 +83,6 @@ export async function buyToken(data: Data) {
       ...options,
     }
 
-    if (
-      client.referralFeeRecipient &&
-      client.referralFee &&
-      !options.feesOnTop
-    ) {
-      params.feesOnTop = [
-        `${client.referralFeeRecipient}:${client.referralFee}`,
-      ]
-    }
-
     if (tokens) {
       params.tokens = tokens?.map(
         (token) => `${token.contract}:${token.tokenId}`

--- a/packages/client/src/actions/index.ts
+++ b/packages/client/src/actions/index.ts
@@ -8,10 +8,9 @@ import { version } from '../../package.json'
  * @param apiKey Reservoir API key to be applied to all api
  * @param source Used to manually override the source domain used to attribute local orders
  * @param automatedRoyalties If true, royalties will be automatically included, defaults to true. Only relevant for creating orders.
- * @param referralFee Fee in bps applied on top of an order when filling it (buying)
- * @param referralFeeRecipient Referral fee recipient
  * @param marketplaceFee Fee in bps included when creating an order (listing & bidding)
  * @param marketplaceFeeRecipient Marketplace fee recipient
+ * @param normalizeRoyalties Normalize orders that don't have royalties by apply royalties on top of them
  */
 export type ReservoirClientOptions = {
   apiBase: string
@@ -19,8 +18,6 @@ export type ReservoirClientOptions = {
   uiVersion?: string
   source?: string
   automatedRoyalties?: boolean
-  referralFee?: number
-  referralFeeRecipient?: string
   marketplaceFee?: number
   marketplaceFeeRecipient?: string
   normalizeRoyalties?: boolean
@@ -36,8 +33,6 @@ export class ReservoirClient {
   source?: string
   apiKey?: string
   uiVersion?: string
-  referralFee?: number
-  referralFeeRecipient?: string
   marketplaceFee?: number
   marketplaceFeeRecipient?: string
   automatedRoyalties?: boolean
@@ -52,8 +47,6 @@ export class ReservoirClient {
     this.uiVersion = options.uiVersion
     this.apiBase = options.apiBase
     this.automatedRoyalties = options.automatedRoyalties
-    this.referralFee = options.referralFee
-    this.referralFeeRecipient = options.referralFeeRecipient
     this.marketplaceFee = options.marketplaceFee
     this.marketplaceFeeRecipient = options.marketplaceFeeRecipient
     this.normalizeRoyalties = options.normalizeRoyalties
@@ -79,12 +72,6 @@ export class ReservoirClient {
     this.apiKey = options.apiKey ? options.apiKey : this.apiKey
     this.uiVersion = options.uiVersion ? options.uiVersion : this.uiVersion
     this.apiBase = options.apiBase ? options.apiBase : this.apiBase
-    this.referralFee = options.referralFee
-      ? options.referralFee
-      : this.referralFee
-    this.referralFeeRecipient = options.referralFeeRecipient
-      ? options.referralFeeRecipient
-      : this.referralFeeRecipient
     this.marketplaceFee = options.marketplaceFee
       ? options.marketplaceFee
       : this.marketplaceFee

--- a/packages/ui/src/modal/buy/BuyModalRenderer.tsx
+++ b/packages/ui/src/modal/buy/BuyModalRenderer.tsx
@@ -267,16 +267,6 @@ export const BuyModalRenderer: FC<Props> = ({
 
           floorPrice = floorPrice + fee
           setReferrerFee(fee)
-        } else if (
-          referrerFeeBps !== null &&
-          referrer !== null &&
-          client?.referralFee &&
-          client?.referralFeeRecipient
-        ) {
-          const fee = (client.referralFee / 10000) * floorPrice
-
-          floorPrice = floorPrice + fee
-          setReferrerFee(fee)
         }
         setTotalPrice(floorPrice)
         setBuyStep(BuyStep.Checkout)

--- a/packages/ui/src/modal/buy/BuyModalRenderer.tsx
+++ b/packages/ui/src/modal/buy/BuyModalRenderer.tsx
@@ -14,6 +14,7 @@ import {
   ReservoirClientActions,
 } from '@reservoir0x/reservoir-kit-client'
 import { toFixed } from '../../lib/numbers'
+import { formatUnits } from 'ethers/lib/utils'
 
 export enum BuyStep {
   Checkout,
@@ -149,7 +150,13 @@ export const BuyModalRenderer: FC<Props> = ({
     }
 
     if (referrer && referrerFeeBps) {
-      options.feesOnTop = [`${referrer}:${referrerFeeBps}`]
+      const price = toFixed(totalPrice, currency?.decimals || 18)
+      const fee = utils
+        .parseUnits(`${price}`, currency?.decimals)
+        .mul(referrerFeeBps)
+        .div(10000)
+      const atomicUnitsFee = formatUnits(fee, 0)
+      options.feesOnTop = [`${referrer}:${atomicUnitsFee}`]
     } else if (referrer === null && referrerFeeBps === null) {
       delete options.feesOnTop
     }
@@ -247,6 +254,7 @@ export const BuyModalRenderer: FC<Props> = ({
     client,
     signer,
     currency,
+    totalPrice,
   ])
 
   useEffect(() => {


### PR DESCRIPTION
* Convert bps fee to atomic unit in BuyModalRenderer before calling buyToken
* BREAKING: Remove global referrerFee and referrerRecipient due to difficulty calculating fee without price and currency in buyToken method.