### PR TITLE
fix: wrong git repo link

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,6 +56,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/@reservoir0x/reservoir-kit.git"
+    "url": "https://github.com/reservoirprotocol/reservoir-kit"
   }
 }


### PR DESCRIPTION
this link will shows on NPM page, and it is 404 now

<img width="1205" alt="Snipaste_2022-12-15_22-11-14" src="https://user-images.githubusercontent.com/10740043/207882832-f95fffdc-8ff2-4a7c-adf6-39c4b81f9d0e.png">
