### PR TITLE
Break out StepsData into different types to improve DX

### DIFF
--- a/packages/ui/src/modal/acceptBid/AcceptBidModal.tsx
+++ b/packages/ui/src/modal/acceptBid/AcceptBidModal.tsx
@@ -22,7 +22,7 @@ import TokenLineItem from '../TokenLineItem'
 import {
   AcceptBidStep,
   AcceptBidModalRenderer,
-  StepData,
+  AcceptBidStepData,
 } from './AcceptBidModalRenderer'
 import Fees from './Fees'
 import { useFallbackState, useReservoirClient, useTimeSince } from '../../hooks'
@@ -44,11 +44,11 @@ type Props = Pick<Parameters<typeof Modal>['0'], 'trigger'> & {
   onBidAccepted?: (data: BidData) => void
   onClose?: (
     data: BidData,
-    stepData: StepData | null,
+    stepData: AcceptBidStepData | null,
     currentStep: AcceptBidStep
   ) => void
   onBidAcceptError?: (error: Error, data: BidData) => void
-  onCurrentStepUpdate?: (data: StepData) => void
+  onCurrentStepUpdate?: (data: AcceptBidStepData) => void
 }
 
 function titleForStep(step: AcceptBidStep) {

--- a/packages/ui/src/modal/acceptBid/AcceptBidModalRenderer.tsx
+++ b/packages/ui/src/modal/acceptBid/AcceptBidModalRenderer.tsx
@@ -26,7 +26,7 @@ export enum AcceptBidStep {
   Unavailable,
 }
 
-export type StepData = {
+export type AcceptBidStepData = {
   totalSteps: number
   currentStep: Execute['steps'][0]
   currentStepItem?: NonNullable<Execute['steps'][0]['items']>[0]
@@ -61,7 +61,7 @@ type ChildrenProps = {
   usdPrice: ReturnType<typeof useCoinConversion>
   address?: string
   etherscanBaseUrl: string
-  stepData: StepData | null
+  stepData: AcceptBidStepData | null
   acceptBid: () => void
   setAcceptBidStep: React.Dispatch<React.SetStateAction<AcceptBidStep>>
 }
@@ -84,7 +84,7 @@ export const AcceptBidModalRenderer: FC<Props> = ({
   children,
 }) => {
   const { data: signer } = useSigner()
-  const [stepData, setStepData] = useState<StepData | null>(null)
+  const [stepData, setStepData] = useState<AcceptBidStepData | null>(null)
   const [totalPrice, setTotalPrice] = useState(0)
   const [acceptBidStep, setAcceptBidStep] = useState<AcceptBidStep>(
     AcceptBidStep.Checkout

--- a/packages/ui/src/modal/acceptBid/Progress.tsx
+++ b/packages/ui/src/modal/acceptBid/Progress.tsx
@@ -1,6 +1,6 @@
 import { Anchor, Box, Flex, Text } from '../../primitives'
 import React, { FC } from 'react'
-import { AcceptBidStep, StepData } from './AcceptBidModalRenderer'
+import { AcceptBidStep, AcceptBidStepData } from './AcceptBidModalRenderer'
 
 import TransactionProgress from '../TransactionProgress'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -15,7 +15,7 @@ type Props = {
     image: string
   }
   tokenImage?: string
-  stepData: StepData | null
+  stepData: AcceptBidStepData | null
 }
 
 export const Progress: FC<Props> = ({

--- a/packages/ui/src/modal/bid/BidModal.tsx
+++ b/packages/ui/src/modal/bid/BidModal.tsx
@@ -29,7 +29,7 @@ import {
   BidStep,
   BidData,
   Trait,
-  StepData,
+  BidModalStepData,
 } from './BidModalRenderer'
 import TokenStats from './TokenStats'
 import dayjs from 'dayjs'
@@ -65,7 +65,7 @@ type Props = Pick<Parameters<typeof Modal>['0'], 'trigger'> & {
   onViewOffers?: () => void
   onClose?: (
     data: BidCallbackData,
-    stepData: StepData | null,
+    stepData: BidModalStepData | null,
     currentStep: BidStep
   ) => void
   onBidComplete?: (data: any) => void

--- a/packages/ui/src/modal/bid/BidModalRenderer.tsx
+++ b/packages/ui/src/modal/bid/BidModalRenderer.tsx
@@ -77,7 +77,7 @@ type ChildrenProps = {
   transactionError?: Error | null
   expirationOptions: ExpirationOption[]
   expirationOption: ExpirationOption
-  stepData: StepData | null
+  stepData: BidModalStepData | null
   setBidStep: React.Dispatch<React.SetStateAction<BidStep>>
   setBidAmount: React.Dispatch<React.SetStateAction<string>>
   setExpirationOption: React.Dispatch<React.SetStateAction<ExpirationOption>>
@@ -99,7 +99,7 @@ export type BidData = Parameters<
   ReservoirClientActions['placeBid']
 >['0']['bids'][0]
 
-export type StepData = {
+export type BidModalStepData = {
   totalSteps: number
   stepProgress: number
   currentStep: Execute['steps'][0]
@@ -124,7 +124,7 @@ export const BidModalRenderer: FC<Props> = ({
   const [hasEnoughWrappedCurrency, setHasEnoughWrappedCurrency] =
     useState(false)
   const [amountToWrap, setAmountToWrap] = useState('')
-  const [stepData, setStepData] = useState<StepData | null>(null)
+  const [stepData, setStepData] = useState<BidModalStepData | null>(null)
   const [bidData, setBidData] = useState<BidData | null>(null)
   const contract = collectionId ? collectionId?.split(':')[0] : undefined
   const [trait, setTrait] = useState<Trait>(attribute)

--- a/packages/ui/src/modal/buy/BuyModal.tsx
+++ b/packages/ui/src/modal/buy/BuyModal.tsx
@@ -23,7 +23,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import TokenLineItem from '../TokenLineItem'
-import { BuyModalRenderer, BuyStep, StepData } from './BuyModalRenderer'
+import { BuyModalRenderer, BuyStep, BuyModalStepData } from './BuyModalRenderer'
 import { Execute } from '@reservoir0x/reservoir-sdk'
 import ProgressBar from '../ProgressBar'
 import { useNetwork } from 'wagmi'
@@ -48,7 +48,7 @@ type Props = Pick<Parameters<typeof Modal>['0'], 'trigger'> & {
   onPurchaseError?: (error: Error, data: PurchaseData) => void
   onClose?: (
     data: PurchaseData,
-    stepData: StepData | null,
+    stepData: BuyModalStepData | null,
     currentStep: BuyStep
   ) => void
 }

--- a/packages/ui/src/modal/buy/BuyModalRenderer.tsx
+++ b/packages/ui/src/modal/buy/BuyModalRenderer.tsx
@@ -24,7 +24,7 @@ export enum BuyStep {
   Unavailable,
 }
 
-export type StepData = {
+export type BuyModalStepData = {
   totalSteps: number
   stepProgress: number
   currentStep: Execute['steps'][0]
@@ -59,7 +59,7 @@ type ChildrenProps = {
   address?: string
   blockExplorerBaseUrl: string
   steps: Execute['steps'] | null
-  stepData: StepData | null
+  stepData: BuyModalStepData | null
   quantity: number
   setBuyStep: React.Dispatch<React.SetStateAction<BuyStep>>
   setQuantity: React.Dispatch<React.SetStateAction<number>>
@@ -93,7 +93,7 @@ export const BuyModalRenderer: FC<Props> = ({
   const [buyStep, setBuyStep] = useState<BuyStep>(BuyStep.Checkout)
   const [transactionError, setTransactionError] = useState<Error | null>()
   const [hasEnoughCurrency, setHasEnoughCurrency] = useState(true)
-  const [stepData, setStepData] = useState<StepData | null>(null)
+  const [stepData, setStepData] = useState<BuyModalStepData | null>(null)
   const [steps, setSteps] = useState<Execute['steps'] | null>(null)
   const [quantity, setQuantity] = useState(1)
   const { chain: activeChain } = useNetwork()

--- a/packages/ui/src/modal/cancelBid/CancelBidModalRenderer.tsx
+++ b/packages/ui/src/modal/cancelBid/CancelBidModalRenderer.tsx
@@ -9,7 +9,7 @@ export enum CancelStep {
   Complete,
 }
 
-export type StepData = {
+export type CancelBidStepData = {
   totalSteps: number
   stepProgress: number
   currentStep: Execute['steps'][0]
@@ -26,7 +26,7 @@ type ChildrenProps = {
   usdPrice: ReturnType<typeof useCoinConversion>
   blockExplorerBaseUrl: string
   steps: Execute['steps'] | null
-  stepData: StepData | null
+  stepData: CancelBidStepData | null
   setCancelStep: React.Dispatch<React.SetStateAction<CancelStep>>
   cancelOrder: () => void
 }
@@ -47,7 +47,7 @@ export const CancelBidModalRenderer: FC<Props> = ({
   const { data: signer } = useSigner()
   const [cancelStep, setCancelStep] = useState<CancelStep>(CancelStep.Cancel)
   const [transactionError, setTransactionError] = useState<Error | null>()
-  const [stepData, setStepData] = useState<StepData | null>(null)
+  const [stepData, setStepData] = useState<CancelBidStepData | null>(null)
   const [steps, setSteps] = useState<Execute['steps'] | null>(null)
   const { chain: activeChain } = useNetwork()
   const blockExplorerBaseUrl =

--- a/packages/ui/src/modal/cancelListing/CancelListingModalRenderer.tsx
+++ b/packages/ui/src/modal/cancelListing/CancelListingModalRenderer.tsx
@@ -9,7 +9,7 @@ export enum CancelStep {
   Complete,
 }
 
-export type StepData = {
+export type CancelListingStepData = {
   totalSteps: number
   stepProgress: number
   currentStep: Execute['steps'][0]
@@ -27,7 +27,7 @@ type ChildrenProps = {
   usdPrice: ReturnType<typeof useCoinConversion>
   blockExplorerBaseUrl: string
   steps: Execute['steps'] | null
-  stepData: StepData | null
+  stepData: CancelListingStepData | null
   setCancelStep: React.Dispatch<React.SetStateAction<CancelStep>>
   cancelOrder: () => void
 }
@@ -48,7 +48,7 @@ export const CancelListingModalRenderer: FC<Props> = ({
   const { data: signer } = useSigner()
   const [cancelStep, setCancelStep] = useState<CancelStep>(CancelStep.Cancel)
   const [transactionError, setTransactionError] = useState<Error | null>()
-  const [stepData, setStepData] = useState<StepData | null>(null)
+  const [stepData, setStepData] = useState<CancelListingStepData | null>(null)
   const [steps, setSteps] = useState<Execute['steps'] | null>(null)
   const { chain: activeChain } = useNetwork()
   const blockExplorerBaseUrl =

--- a/packages/ui/src/modal/list/ListModal.tsx
+++ b/packages/ui/src/modal/list/ListModal.tsx
@@ -24,7 +24,7 @@ import {
   ListingData,
   ListModalRenderer,
   ListStep,
-  StepData,
+  ListModalStepData,
 } from './ListModalRenderer'
 import { ModalSize } from '../Modal'
 import { faChevronLeft, faCheckCircle } from '@fortawesome/free-solid-svg-icons'
@@ -60,7 +60,7 @@ type Props = Pick<Parameters<typeof Modal>['0'], 'trigger'> & {
   onListingError?: (error: Error, data: ListingCallbackData) => void
   onClose?: (
     data: ListingCallbackData,
-    stepData: StepData | null,
+    stepData: ListModalStepData | null,
     currentStep: ListStep
   ) => void
 }

--- a/packages/ui/src/modal/list/ListModalRenderer.tsx
+++ b/packages/ui/src/modal/list/ListModalRenderer.tsx
@@ -45,7 +45,7 @@ export type ListingData = {
   marketplace: Marketplace
 }
 
-export type ListStepData = {
+export type ListModalStepData = {
   totalSteps: number
   stepProgress: number
   currentStep: Execute['steps'][0]
@@ -66,7 +66,7 @@ type ChildrenProps = {
   localMarketplace: Marketplace | null
   listingData: ListingData[]
   transactionError?: Error | null
-  stepData: ListStepData | null
+  stepData: ListModalStepData | null
   currencies: Currency[]
   currency: Currency
   quantity: number
@@ -134,7 +134,7 @@ export const ListModalRenderer: FC<Props> = ({
   const [allMarketplaces] = useMarketplaces(true)
   const [loadedInitalPrice, setLoadedInitalPrice] = useState(false)
   const [transactionError, setTransactionError] = useState<Error | null>()
-  const [stepData, setStepData] = useState<ListStepData | null>(null)
+  const [stepData, setStepData] = useState<ListModalStepData | null>(null)
   const [localMarketplace, setLocalMarketplace] = useState<Marketplace | null>(
     null
   )

--- a/packages/ui/src/modal/list/ListModalRenderer.tsx
+++ b/packages/ui/src/modal/list/ListModalRenderer.tsx
@@ -45,7 +45,7 @@ export type ListingData = {
   marketplace: Marketplace
 }
 
-export type StepData = {
+export type ListStepData = {
   totalSteps: number
   stepProgress: number
   currentStep: Execute['steps'][0]
@@ -66,7 +66,7 @@ type ChildrenProps = {
   localMarketplace: Marketplace | null
   listingData: ListingData[]
   transactionError?: Error | null
-  stepData: StepData | null
+  stepData: ListStepData | null
   currencies: Currency[]
   currency: Currency
   quantity: number
@@ -134,7 +134,7 @@ export const ListModalRenderer: FC<Props> = ({
   const [allMarketplaces] = useMarketplaces(true)
   const [loadedInitalPrice, setLoadedInitalPrice] = useState(false)
   const [transactionError, setTransactionError] = useState<Error | null>()
-  const [stepData, setStepData] = useState<StepData | null>(null)
+  const [stepData, setStepData] = useState<ListStepData | null>(null)
   const [localMarketplace, setLocalMarketplace] = useState<Marketplace | null>(
     null
   )


### PR DESCRIPTION
Each Modal will now have it's own StepData that way when the bundler exports the type it's easier to determine which to use (rather than StepData1 etc which is generated by the bundler.