### PR TITLE
Fix: Reservoir UI kit dependency giving error for running next demo project locally

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@radix-ui/colors": "^0.1.8",
     "@rainbow-me/rainbowkit": "0.12.0",
-    "@reservoir0x/reservoir-kit-ui": "workspace:*",
+    "@reservoir0x/reservoir-kit-ui": "latest",
     "@stitches/react": "1.3.1-1",
     "ethers": "^5.6.9",
     "next": "latest",


### PR DESCRIPTION
Using `workspace:*` just after a fresh clone gives error to run the `demo` next project.