### PR TITLE
fix sendTransaction to allow privateKeyAccounts

### DIFF
--- a/packages/sdk/src/utils/transaction.ts
+++ b/packages/sdk/src/utils/transaction.ts
@@ -17,7 +17,7 @@ export async function sendTransactionSafely(
   const transaction = await signer.sendTransaction({
     chain: viemChain,
     data: data.data,
-    account: data.from,
+    account: signer.account ?? data.from, // use signer.account if it's defined
     to: data.to,
     value: data.value,
   })

--- a/packages/sdk/src/utils/transaction.ts
+++ b/packages/sdk/src/utils/transaction.ts
@@ -1,4 +1,4 @@
-import { PublicClient, Transaction, WalletClient } from 'viem'
+import { PublicClient, Transaction, WalletClient, hexToBigInt } from 'viem'
 import { LogLevel, getClient } from '..'
 import { Chain } from 'viem'
 
@@ -19,7 +19,9 @@ export async function sendTransactionSafely(
     data: data.data,
     account: signer.account ?? data.from, // use signer.account if it's defined
     to: data.to,
-    value: data.value,
+    value: hexToBigInt(data.value),
+    ...(data.maxFeePerGas && {maxFeePerGas: hexToBigInt(data.maxFeePerGas)}),
+    ...(data.maxPriorityFeePerGas && {maxPriorityFeePerGas: hexToBigInt(data.maxPriorityFeePerGas)}),
   })
   setTx(transaction)
 

--- a/packages/sdk/tests/unit/ExecuteSteps.test.ts
+++ b/packages/sdk/tests/unit/ExecuteSteps.test.ts
@@ -5,7 +5,7 @@ import {
   ReservoirClient,
 } from '@reservoir0x/reservoir-sdk'
 import axios from 'axios'
-import { createWalletClient, http, WalletClient } from 'viem'
+import { createWalletClient, hexToBigInt, http, WalletClient } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 
@@ -522,9 +522,9 @@ describe(`It should test the executeSteps Method.`, (): void => {
 
         expect(firstArg).toEqual(
           expect.objectContaining({
-            account: '0xd6044091d0b41efb3402ca05ba4068f969fdd9e4',
+            account: wallet.account,
             to: '0x00000000000000adc04c56bf30ac9d3c0aaf14dc',
-            value: '0x08e1bc9bf04000',
+            value: hexToBigInt('0x08e1bc9bf04000'),
           })
         )
       })


### PR DESCRIPTION
Previously, if the user built the signer from a private account `sendTransaction` would fail with error: `unsupported method: eth_sendTransaction`. However, since the signer is a private account, then account.type should === "local" and viem should be using `eth_sendRawTransaction` per here: https://github.com/wagmi-dev/viem/blob/main/src/actions/wallet/sendTransaction.ts#L131-L157. Clearly, there was some configuration in reservoir that coerced account.type to something other than "local".

The previous code coerced `account` to a string by assigning `data.from` to account. By coercing account to a string the account.type is inadvertently transformed into "json-rpc" [here](https://github.com/wagmi-dev/viem/blob/main/src/actions/wallet/sendTransaction.ts#L117) and [here](https://github.com/wagmi-dev/viem/blob/main/src/accounts/utils/parseAccount.ts#L6)