### PR TITLE
Update TokenMedia component 

### DIFF
--- a/demo/pages/ui/tokenMedia.tsx
+++ b/demo/pages/ui/tokenMedia.tsx
@@ -1,6 +1,10 @@
 import { NextPage } from 'next'
-import { TokenMedia, useTokens } from '@reservoir0x/reservoir-kit-ui'
-import { useState } from 'react'
+import {
+  TokenMedia,
+  useReservoirClient,
+  useTokens,
+} from '@reservoir0x/reservoir-kit-ui'
+import { ComponentPropsWithoutRef, useState } from 'react'
 import ThemeSwitcher from 'components/ThemeSwitcher'
 
 const DEFAULT_COLLECTION_ID =
@@ -11,10 +15,16 @@ const DEFAULT_TOKEN_ID = process.env.NEXT_PUBLIC_DEFAULT_TOKEN_ID || '2'
 const TokenMediaPage: NextPage = () => {
   const [collectionId, setCollectionId] = useState(DEFAULT_COLLECTION_ID)
   const [tokenId, setTokenId] = useState(DEFAULT_TOKEN_ID)
-  const [preview, setPreview] = useState(false)
   const [showGrid, setShowGrid] = useState(true)
-  const [enableOnChainImageFallback, setEnableOnChainImageFallback] =
-    useState(false)
+  const [staticOnly, setStaticOnly] = useState(false)
+  const [imageResolution, setImageResolution] = useState('medium')
+  const [disableOnChainRendering, setDisableOnChainRendering] = useState(false)
+  const [fallbackMode, setFallbackMode] =
+    useState<ComponentPropsWithoutRef<typeof TokenMedia>['fallbackMode']>(
+      'default'
+    )
+  const client = useReservoirClient()
+  const chain = client?.currentChain()
 
   const { data: tokens } = useTokens(
     collectionId
@@ -70,14 +80,6 @@ const TokenMediaPage: NextPage = () => {
           style={{ width: 250 }}
         />
       </div>
-      <div>
-        <label>enableOnChainImageFallback: </label>
-        <input
-          type="checkbox"
-          checked={enableOnChainImageFallback}
-          onChange={(e) => setEnableOnChainImageFallback(e.target.checked)}
-        />
-      </div>
       {!showGrid && (
         <div>
           <label>Token Id: </label>
@@ -91,14 +93,54 @@ const TokenMediaPage: NextPage = () => {
         </div>
       )}
       <div>
-        <label>Preview: </label>
+        <label>staticOnly: </label>
         <input
           type="checkbox"
-          checked={preview}
+          checked={staticOnly}
           onChange={(e) => {
-            setPreview(e.target.checked)
+            setStaticOnly(e.target.checked)
           }}
         />
+      </div>
+      <div>
+        <label>imageResolution: </label>
+        <input
+          placeholder="small | medium | large"
+          type="text"
+          value={imageResolution}
+          onChange={(e) => setImageResolution(e.target.value)}
+        />
+      </div>
+      <div>
+        <label>disableOnChainRendering: </label>
+        <input
+          type="checkbox"
+          checked={disableOnChainRendering}
+          onChange={(e) => setDisableOnChainRendering(e.target.checked)}
+        />
+      </div>
+      <div style={{ display: 'flex', gap: 10 }}>
+        <label>fallbackMode: </label>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <div>
+            <input
+              type="radio"
+              value="default"
+              checked={fallbackMode === 'default'}
+              onChange={() => setFallbackMode('default')}
+            />
+            <label>default</label>
+          </div>
+          <div>
+            <input
+              type="radio"
+              value="simple"
+              checked={fallbackMode === 'simple'}
+              onChange={() => setFallbackMode('simple')}
+            />
+            <label>simple</label>
+          </div>
+        </div>
       </div>
       {showGrid ? (
         <div
@@ -112,18 +154,30 @@ const TokenMediaPage: NextPage = () => {
             <TokenMedia
               key={i}
               token={token?.token}
-              preview={preview}
+              staticOnly={staticOnly}
+              imageResolution={
+                imageResolution as ComponentPropsWithoutRef<
+                  typeof TokenMedia
+                >['imageResolution']
+              }
               onRefreshToken={() => {
                 window.alert('Token was refreshed!')
               }}
-              enableOnChainImageFallback={enableOnChainImageFallback}
+              disableOnChainRendering={disableOnChainRendering}
+              fallbackMode={fallbackMode}
+              chainId={chain?.id}
             />
           ))}
         </div>
       ) : (
         <TokenMedia
           token={tokens && tokens[0] ? tokens[0].token : undefined}
-          preview={preview}
+          staticOnly={staticOnly}
+          imageResolution={
+            imageResolution as ComponentPropsWithoutRef<
+              typeof TokenMedia
+            >['imageResolution']
+          }
           style={{
             minWidth: '400px',
             minHeight: '400px',
@@ -131,7 +185,8 @@ const TokenMediaPage: NextPage = () => {
           onRefreshToken={() => {
             window.alert('Token was refreshed!')
           }}
-          enableOnChainImageFallback={enableOnChainImageFallback}
+          disableOnChainRendering={disableOnChainRendering}
+          chainId={chain?.id}
         />
       )}
       <ThemeSwitcher />

--- a/demo/pages/ui/tokenMedia.tsx
+++ b/demo/pages/ui/tokenMedia.tsx
@@ -13,6 +13,8 @@ const TokenMediaPage: NextPage = () => {
   const [tokenId, setTokenId] = useState(DEFAULT_TOKEN_ID)
   const [preview, setPreview] = useState(false)
   const [showGrid, setShowGrid] = useState(true)
+  const [enableOnChainImageFallback, setEnableOnChainImageFallback] =
+    useState(false)
 
   const { data: tokens } = useTokens(
     collectionId
@@ -68,6 +70,14 @@ const TokenMediaPage: NextPage = () => {
           style={{ width: 250 }}
         />
       </div>
+      <div>
+        <label>enableOnChainImageFallback: </label>
+        <input
+          type="checkbox"
+          checked={enableOnChainImageFallback}
+          onChange={(e) => setEnableOnChainImageFallback(e.target.checked)}
+        />
+      </div>
       {!showGrid && (
         <div>
           <label>Token Id: </label>
@@ -106,6 +116,7 @@ const TokenMediaPage: NextPage = () => {
               onRefreshToken={() => {
                 window.alert('Token was refreshed!')
               }}
+              enableOnChainImageFallback={enableOnChainImageFallback}
             />
           ))}
         </div>
@@ -120,6 +131,7 @@ const TokenMediaPage: NextPage = () => {
           onRefreshToken={() => {
             window.alert('Token was refreshed!')
           }}
+          enableOnChainImageFallback={enableOnChainImageFallback}
         />
       )}
       <ThemeSwitcher />

--- a/packages/ui/src/components/TokenMedia/TokenFallback.tsx
+++ b/packages/ui/src/components/TokenMedia/TokenFallback.tsx
@@ -1,32 +1,26 @@
-import React, {
-  FC,
-  ComponentPropsWithoutRef,
-  CSSProperties,
-  useEffect,
-  useState,
-} from 'react'
+import React, { FC, ComponentPropsWithoutRef, CSSProperties } from 'react'
 import { Button, Flex, Text } from '../../primitives'
 import TokenMedia from './index'
 import { defaultHeaders } from '../../lib/swr'
 import { useReservoirClient } from '../../hooks'
 import { paths } from '@reservoir0x/reservoir-sdk'
-import { Address, erc721ABI, useContractRead } from 'wagmi'
-import { convertTokenUriToImage } from '../../lib/processTokenURI'
+import { faImage } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 type TokenFallbackProps = {
+  mode?: 'default' | 'simple'
   style?: CSSProperties
   className?: string
   token: ComponentPropsWithoutRef<typeof TokenMedia>['token']
-  enableOnChainImageFallback?: boolean
   chainId?: number
   onRefreshClicked: () => void
 }
 
 const TokenFallback: FC<TokenFallbackProps> = ({
+  mode,
   style,
   className,
   token,
-  enableOnChainImageFallback,
   chainId,
   onRefreshClicked,
 }) => {
@@ -34,31 +28,6 @@ const TokenFallback: FC<TokenFallbackProps> = ({
   const reservoirChain = chainId
     ? client?.chains.find((chain) => chain.id === chainId)
     : client?.currentChain()
-
-  const contract = token?.collection?.id?.split(':')[0] as Address
-
-  const [onChainImage, setOnChainImage] = useState('')
-  const [onChainImageBroken, setOnChainImageBroken] = useState(false)
-
-  const { data: tokenURI, isError } = useContractRead(
-    enableOnChainImageFallback
-      ? {
-          address: contract,
-          abi: erc721ABI,
-          functionName: 'tokenURI',
-          args: token?.tokenId ? [BigInt(token?.tokenId)] : undefined,
-        }
-      : undefined
-  )
-
-  useEffect(() => {
-    if (tokenURI) {
-      ;(async () => {
-        const updatedOnChainImage = await convertTokenUriToImage(tokenURI)
-        setOnChainImage(updatedOnChainImage)
-      })()
-    }
-  }, [tokenURI])
 
   return (
     <Flex
@@ -68,22 +37,8 @@ const TokenFallback: FC<TokenFallbackProps> = ({
       css={{ gap: '$2', aspectRatio: '1/1', p: '$2', ...style }}
       className={className}
     >
-      {enableOnChainImageFallback &&
-      onChainImage &&
-      !isError &&
-      !onChainImageBroken ? (
-        <img
-          src={onChainImage}
-          style={{
-            width: '150px',
-            height: '150px',
-            objectFit: 'cover',
-            ...style,
-          }}
-          onError={(e: React.SyntheticEvent<HTMLImageElement, Event>) => {
-            setOnChainImageBroken(true)
-          }}
-        />
+      {mode === 'simple' ? (
+        <FontAwesomeIcon icon={faImage} style={{ height: '50%' }} />
       ) : (
         <>
           {token?.collection?.image && (

--- a/packages/ui/src/components/TokenMedia/TokenFallback.tsx
+++ b/packages/ui/src/components/TokenMedia/TokenFallback.tsx
@@ -1,14 +1,23 @@
-import React, { FC, ComponentPropsWithoutRef, CSSProperties } from 'react'
+import React, {
+  FC,
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  useEffect,
+  useState,
+} from 'react'
 import { Button, Flex, Text } from '../../primitives'
 import TokenMedia from './index'
 import { defaultHeaders } from '../../lib/swr'
 import { useReservoirClient } from '../../hooks'
 import { paths } from '@reservoir0x/reservoir-sdk'
+import { Address, erc721ABI, useContractRead } from 'wagmi'
+import { convertTokenUriToImage } from '../../lib/processTokenURI'
 
 type TokenFallbackProps = {
   style?: CSSProperties
   className?: string
   token: ComponentPropsWithoutRef<typeof TokenMedia>['token']
+  enableOnChainImageFallback?: boolean
   chainId?: number
   onRefreshClicked: () => void
 }
@@ -17,6 +26,7 @@ const TokenFallback: FC<TokenFallbackProps> = ({
   style,
   className,
   token,
+  enableOnChainImageFallback,
   chainId,
   onRefreshClicked,
 }) => {
@@ -24,6 +34,31 @@ const TokenFallback: FC<TokenFallbackProps> = ({
   const reservoirChain = chainId
     ? client?.chains.find((chain) => chain.id === chainId)
     : client?.currentChain()
+
+  const contract = token?.collection?.id?.split(':')[0] as Address
+
+  const [onChainImage, setOnChainImage] = useState('')
+  const [onChainImageBroken, setOnChainImageBroken] = useState(false)
+
+  const { data: tokenURI, isError } = useContractRead(
+    enableOnChainImageFallback
+      ? {
+          address: contract,
+          abi: erc721ABI,
+          functionName: 'tokenURI',
+          args: token?.tokenId ? [BigInt(token?.tokenId)] : undefined,
+        }
+      : undefined
+  )
+
+  useEffect(() => {
+    if (tokenURI) {
+      ;(async () => {
+        const updatedOnChainImage = await convertTokenUriToImage(tokenURI)
+        setOnChainImage(updatedOnChainImage)
+      })()
+    }
+  }, [tokenURI])
 
   return (
     <Flex
@@ -33,45 +68,70 @@ const TokenFallback: FC<TokenFallbackProps> = ({
       css={{ gap: '$2', aspectRatio: '1/1', p: '$2', ...style }}
       className={className}
     >
-      {token?.collection?.image && (
+      {enableOnChainImageFallback &&
+      onChainImage &&
+      !isError &&
+      !onChainImageBroken ? (
         <img
-          style={{ width: 64, height: 64, objectFit: 'cover', borderRadius: 8 }}
-          src={token?.collection?.image}
+          src={onChainImage}
+          style={{
+            width: '150px',
+            height: '150px',
+            objectFit: 'cover',
+            ...style,
+          }}
+          onError={(e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+            setOnChainImageBroken(true)
+          }}
         />
+      ) : (
+        <>
+          {token?.collection?.image && (
+            <img
+              style={{
+                width: 64,
+                height: 64,
+                objectFit: 'cover',
+                borderRadius: 8,
+              }}
+              src={token?.collection?.image}
+            />
+          )}
+          <Text style="body2" css={{ textAlign: 'center' }}>
+            No Content Available
+          </Text>
+          <Button
+            color="secondary"
+            onClick={(e) => {
+              e.preventDefault()
+              if (!reservoirChain) {
+                throw 'ReservoirClient missing chain configuration'
+              }
+              onRefreshClicked()
+              const url = `${reservoirChain?.baseApiUrl}/tokens/refresh/v1`
+              const body: paths['/tokens/refresh/v1']['post']['parameters']['body']['body'] =
+                {
+                  token: `${token?.collection?.id}:${token?.tokenId}`,
+                }
+              const headers = {
+                ...defaultHeaders(reservoirChain?.apiKey, client?.version),
+                'Content-Type': 'application/json',
+              }
+              fetch(url, {
+                headers,
+                method: 'POST',
+                body: JSON.stringify(body),
+              })
+                .then((res) => res.json())
+                .catch((e) => {
+                  throw e
+                })
+            }}
+          >
+            Refresh
+          </Button>
+        </>
       )}
-      <Text style="body2" css={{ textAlign: 'center' }}>
-        No Content Available
-      </Text>
-      <Button
-        color="secondary"
-        onClick={(e) => {
-          e.preventDefault()
-          if (!reservoirChain) {
-            throw 'ReservoirClient missing chain configuration'
-          }
-          onRefreshClicked()
-          const url = `${reservoirChain?.baseApiUrl}/tokens/refresh/v1`
-          const body: paths['/tokens/refresh/v1']['post']['parameters']['body']['body'] =
-            {
-              token: `${token?.collection?.id}:${token?.tokenId}`,
-            }
-          const headers = {
-            ...defaultHeaders(reservoirChain?.apiKey, client?.version),
-            'Content-Type': 'application/json',
-          }
-          fetch(url, {
-            headers,
-            method: 'POST',
-            body: JSON.stringify(body),
-          })
-            .then((res) => res.json())
-            .catch((e) => {
-              throw e
-            })
-        }}
-      >
-        Refresh
-      </Button>
     </Flex>
   )
 }

--- a/packages/ui/src/components/TokenMedia/index.tsx
+++ b/packages/ui/src/components/TokenMedia/index.tsx
@@ -188,9 +188,7 @@ const TokenMedia: FC<Props> = ({
               style={{ ...computedStyle }}
               alt="Token Image"
               onError={(e: React.SyntheticEvent<HTMLImageElement, Event>) => {
-                if (!isFetchingTokenURI && isUpdatingOnChainImage) {
-                  setOnChainImageBroken(true)
-                }
+                setOnChainImageBroken(true)
               }}
             />
           )}

--- a/packages/ui/src/components/TokenMedia/index.tsx
+++ b/packages/ui/src/components/TokenMedia/index.tsx
@@ -66,6 +66,8 @@ type Props = {
   videoOptions?: VideoHTMLAttributes<HTMLVideoElement>
   audioOptions?: AudioHTMLAttributes<HTMLAudioElement>
   iframeOptions?: IframeHTMLAttributes<HTMLIFrameElement>
+  enableOnChainImageFallback?: boolean
+  prefferedImageSize?: 'small' | 'medium' | 'large'
   fallback?: (mediaType: MediaType | null) => ReactElement | null
   onError?: (e: Event) => void
   onRefreshToken?: () => void
@@ -80,6 +82,7 @@ const TokenMedia: FC<Props> = ({
   videoOptions = {},
   audioOptions = {},
   iframeOptions = {},
+  enableOnChainImageFallback,
   fallback,
   onError = () => {},
   onRefreshToken = () => {},
@@ -129,6 +132,7 @@ const TokenMedia: FC<Props> = ({
           className={className}
           token={token}
           onRefreshClicked={onRefreshToken}
+          enableOnChainImageFallback={enableOnChainImageFallback}
         />
       )
     }


### PR DESCRIPTION
These updates are dependent on this PR: #299. Listed below are the updates to the TokenMedia component:
- changed `preview` prop name to `staticOnly`
- added an `imageResolution` prop with options: `small` | `medium` | `large`
- added onchain rendering logic if there is no token image. Can be disabled with `disableOnChainRendering`
- added `fallbackMode` prop: `default` | `simple`