### PR TITLE
Use custom transport in Public Client configuration

### DIFF
--- a/packages/ethers-wallet-adapter/src/adapter.ts
+++ b/packages/ethers-wallet-adapter/src/adapter.ts
@@ -6,9 +6,14 @@ import {
 import { Signer } from 'ethers/lib/ethers'
 import { arrayify } from 'ethers/lib/utils'
 import { TypedDataSigner } from '@ethersproject/abstract-signer/lib/index'
+import { CustomTransport, HttpTransport } from 'viem'
 
-export const adaptEthersSigner = (signer: Signer): ReservoirWallet => {
+export const adaptEthersSigner = (
+  signer: Signer,
+  transport?: CustomTransport | HttpTransport
+): ReservoirWallet => {
   return {
+    transport,
     address: async () => {
       return signer.getAddress()
     },

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -1,4 +1,4 @@
-import { EIP1193RequestFn, TransportConfig } from 'viem'
+import { CustomTransport, HttpTransport } from 'viem'
 import { paths } from './api'
 export * from './api'
 
@@ -91,5 +91,5 @@ export type ReservoirWallet = {
     step: Execute['steps'][0]
   ) => Promise<`0x${string}` | undefined>
   address: () => Promise<string>
-  transport?: TransportConfig<string, EIP1193RequestFn> & Record<string, any>
+  transport?: CustomTransport | HttpTransport
 }

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -1,3 +1,4 @@
+import { EIP1193RequestFn, TransportConfig } from 'viem'
 import { paths } from './api'
 export * from './api'
 
@@ -90,4 +91,5 @@ export type ReservoirWallet = {
     step: Execute['steps'][0]
   ) => Promise<`0x${string}` | undefined>
   address: () => Promise<string>
+  transport?: TransportConfig<string, EIP1193RequestFn> & Record<string, any>
 }

--- a/packages/sdk/src/utils/executeSteps.ts
+++ b/packages/sdk/src/utils/executeSteps.ts
@@ -1,6 +1,6 @@
 import { Execute, paths, ReservoirWallet, TransactionStepItem } from '../types'
 import { pollUntilHasData, pollUntilOk } from './pollApi'
-import { createPublicClient, http } from 'viem'
+import { createPublicClient, custom, http } from 'viem'
 import { axios } from '../utils'
 import { customChains } from '../utils/customChains'
 import { AxiosRequestConfig, AxiosRequestHeaders } from 'axios'
@@ -92,7 +92,7 @@ export async function executeSteps(
 
   const viemClient = createPublicClient({
     chain: viemChain,
-    transport: http(),
+    transport: wallet.transport ? custom(wallet.transport) : http(),
   })
 
   let json = newJson

--- a/packages/sdk/src/utils/executeSteps.ts
+++ b/packages/sdk/src/utils/executeSteps.ts
@@ -1,6 +1,6 @@
 import { Execute, paths, ReservoirWallet, TransactionStepItem } from '../types'
 import { pollUntilHasData, pollUntilOk } from './pollApi'
-import { createPublicClient, custom, http } from 'viem'
+import { createPublicClient, fallback, http } from 'viem'
 import { axios } from '../utils'
 import { customChains } from '../utils/customChains'
 import { AxiosRequestConfig, AxiosRequestHeaders } from 'axios'
@@ -92,7 +92,7 @@ export async function executeSteps(
 
   const viemClient = createPublicClient({
     chain: viemChain,
-    transport: wallet.transport ? custom(wallet.transport) : http(),
+    transport: wallet.transport ? fallback([wallet.transport, http()]) : http(),
   })
 
   let json = newJson

--- a/packages/sdk/src/utils/viemWallet.ts
+++ b/packages/sdk/src/utils/viemWallet.ts
@@ -11,6 +11,7 @@ export function isViemWalletClient(
 
 export const adaptViemWallet = (wallet: WalletClient): ReservoirWallet => {
   return {
+    transport: wallet.transport,
     address: async () => {
       let address = wallet.account?.address
       if (!address) {

--- a/packages/sdk/src/utils/viemWallet.ts
+++ b/packages/sdk/src/utils/viemWallet.ts
@@ -1,6 +1,6 @@
 import { ReservoirWallet } from '../types'
 import { LogLevel, customChains, getClient } from '../'
-import { Account, WalletClient, hexToBigInt, toBytes } from 'viem'
+import { Account, WalletClient, custom, hexToBigInt, toBytes } from 'viem'
 import * as allChains from 'viem/chains'
 
 export function isViemWalletClient(
@@ -11,7 +11,7 @@ export function isViemWalletClient(
 
 export const adaptViemWallet = (wallet: WalletClient): ReservoirWallet => {
   return {
-    transport: wallet.transport,
+    transport: custom(wallet.transport),
     address: async () => {
       let address = wallet.account?.address
       if (!address) {


### PR DESCRIPTION
For some background, in our SDK, we are using a Public Client for these two functions: `getBlockNumber` and `waitForTransactionReceipt`. The Public Client is currently just using the chain's public RPC URL. It would be ideal if the Public Client could use the same `transport` that is attached to the Wallet Client. This PR experiments with a potential solution for viem Wallet Clients (need to do some more work to make ether's signers work)

This page explains why Wallet Clients don't support public actions [https://viem.sh/docs/faq.html#why-doesn-t-wallet-client-support-public-actions](https://viem.sh/docs/faq.html#why-doesn-t-wallet-client-support-public-actions).

This discussion on viem's repo explains the potential workaround used in this PR (also mentions that the wagmi team may be working on a solution): [https://github.com/wagmi-dev/viem/discussions/731](https://github.com/wagmi-dev/viem/discussions/731)
