### PR TITLE
Round down to avoid decimals when calculating bps feesOnTop

### DIFF
--- a/packages/ui/src/context/CartProvider.tsx
+++ b/packages/ui/src/context/CartProvider.tsx
@@ -1027,11 +1027,12 @@ function cartStore({
         if (cartData.current.feesOnTopBps) {
           const fixedFees = cartData.current.feesOnTopBps.map((fullFee) => {
             const [referrer, feeBps] = fullFee.split(':')
-            const fee =
+            const fee = Math.floor(
               Number(
                 parseUnits(`${expectedPrice}`, currencyDecimals) *
                   BigInt(feeBps)
               ) / 10000
+            )
             const atomicUnitsFee = formatUnits(BigInt(fee), 0)
             return `${referrer}:${atomicUnitsFee}`
           })

--- a/packages/ui/src/modal/buy/BuyModalRenderer.tsx
+++ b/packages/ui/src/modal/buy/BuyModalRenderer.tsx
@@ -311,13 +311,14 @@ export const BuyModalRenderer: FC<Props> = ({
           totalIncludingFees - feeOnTop,
           currency?.decimals || 18
         )
-        const fee =
+        const fee = Math.floor(
           Number(
             parseUnits(
               `${Number(totalFeeTruncated)}`,
               currency?.decimals || 18
             ) * BigInt(feeBps)
           ) / 10000
+        )
         const atomicUnitsFee = formatUnits(BigInt(fee), 0)
         return `${referrer}:${atomicUnitsFee}`
       })

--- a/packages/ui/src/modal/collect/CollectModalRenderer.tsx
+++ b/packages/ui/src/modal/collect/CollectModalRenderer.tsx
@@ -517,13 +517,14 @@ export const CollectModalRenderer: FC<Props> = ({
           total - feeOnTop,
           currency?.decimals || 18
         )
-        const fee =
+        const fee = Math.floor(
           Number(
             parseUnits(
               `${Number(totalFeeTruncated)}`,
               currency?.decimals || 18
             ) * BigInt(feeBps)
           ) / 10000
+        )
         const atomicUnitsFee = formatUnits(BigInt(fee), 0)
         return `${referrer}:${atomicUnitsFee}`
       })


### PR DESCRIPTION
Spoke to george about this. The decimals are generally insignificant once the amount is in wei. In this case rounding down is fine, this is actually what we used to do on the backend api.