### PR TITLE
Buymodal allow opening without signer

### DIFF
--- a/demo/pages/_app.tsx
+++ b/demo/pages/_app.tsx
@@ -45,9 +45,9 @@ const { chains, publicClient } = configureChains(
     allChains.optimism,
     allChains.arbitrum,
     allChains.zora,
-    customChains.base,
+    allChains.base,
     allChains.avalanche,
-    customChains.linea,
+    allChains.linea,
   ],
   [alchemyProvider({ apiKey: ALCHEMY_KEY }), publicProvider()]
 )
@@ -139,16 +139,22 @@ const AppWrapper: FC<any> = ({ children }) => {
             },
             {
               baseApiUrl: 'https://api-base.reservoir.tools',
-              id: customChains.base.id,
-              active: CHAIN_ID === customChains.base.id,
+              id: allChains.base.id,
+              active: CHAIN_ID === allChains.base.id,
               apiKey: API_KEY,
             },
             {
               baseApiUrl: 'https://api-linea.reservoir.tools',
-              id: customChains.linea.id,
-              active: CHAIN_ID === customChains.linea.id,
+              id: allChains.linea.id,
+              active: CHAIN_ID === allChains.linea.id,
               apiKey: API_KEY,
             },
+            {
+              baseApiUrl: 'https://api-arbitrum-nova.reservoir.tools',
+              id: customChains.arbitrumNova.id,
+              active: CHAIN_ID === customChains.arbitrumNova.id,
+              apiKey: API_KEY
+            }
           ],
           marketplaceFees: MARKETPLACE_FEES,
           source: SOURCE,

--- a/demo/pages/modal/buy.tsx
+++ b/demo/pages/modal/buy.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from 'next'
 import { BuyModal } from '@reservoir0x/reservoir-kit-ui'
-import { ConnectButton } from '@rainbow-me/rainbowkit'
+import { ConnectButton, useConnectModal } from '@rainbow-me/rainbowkit'
 import ThemeSwitcher from 'components/ThemeSwitcher'
 import { useState } from 'react'
 import DeeplinkCheckbox from 'components/DeeplinkCheckbox'
@@ -26,6 +26,7 @@ const BuyPage: NextPage = () => {
   const hasDeeplink = router.query.deeplink !== undefined
   const [normalizeRoyalties, setNormalizeRoyalties] =
     useState(NORMALIZE_ROYALTIES)
+  const { openConnectModal } = useConnectModal()
 
   return (
     <div
@@ -150,6 +151,9 @@ const BuyPage: NextPage = () => {
         feesOnTopUsd={feesOnTopUsd}
         normalizeRoyalties={normalizeRoyalties}
         openState={hasDeeplink ? deeplinkOpenState : undefined}
+        onConnectWallet={() => {
+          openConnectModal?.()
+        }}
         onGoToToken={() => console.log('Go to token')}
         onPurchaseComplete={(data) => {
           console.log('Purchase Complete', data)

--- a/demo/pages/modal/collect.tsx
+++ b/demo/pages/modal/collect.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from 'next'
 import { CollectModal, CollectModalMode } from '@reservoir0x/reservoir-kit-ui'
-import { ConnectButton } from '@rainbow-me/rainbowkit'
+import { ConnectButton, useConnectModal } from '@rainbow-me/rainbowkit'
 import ThemeSwitcher from 'components/ThemeSwitcher'
 import { useState } from 'react'
 import DeeplinkCheckbox from 'components/DeeplinkCheckbox'
@@ -16,6 +16,8 @@ const NORMALIZE_ROYALTIES = process.env.NEXT_PUBLIC_NORMALIZE_ROYALTIES
 
 const CollectPage: NextPage = () => {
   const router = useRouter()
+  const { openConnectModal } = useConnectModal()
+
   const [collectionId, setCollectionId] = useState(DEFAULT_COLLECTION_ID)
   const [tokenId, setTokenId] = useState<string | undefined>(undefined)
   const [chainId, setChainId] = useState<string | undefined>(undefined)
@@ -154,6 +156,9 @@ const CollectPage: NextPage = () => {
 
       <CollectModal
         chainId={Number(chainId)}
+        onConnectWallet={() => {
+          openConnectModal?.()        
+        }}
         trigger={
           <button
             style={{

--- a/packages/sdk/src/utils/customChains.ts
+++ b/packages/sdk/src/utils/customChains.ts
@@ -1,81 +1,5 @@
 import { Chain } from "viem";
 
-export const zora = {
-  id: 7777777,
-  name: 'Zora',
-  network: 'zora',
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
-  rpcUrls: {
-    default: {
-      http: ['https://rpc.zora.co'],
-    },
-    public: {
-      http: ['https://rpc.zora.co'],
-    },
-  },
-  blockExplorers: {
-    etherscan: {
-      name: 'Zora explorer',
-      url: 'https://explorer.zora.co',
-    },
-    default: {
-      name: 'Zora explorer',
-      url: 'https://explorer.zora.co',
-    },
-  },
-} as const satisfies Chain
-
-export const zoraTestnet = {
-  id: 999,
-  name: 'Zora Testnet',
-  network: 'zora-testnet',
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
-  rpcUrls: {
-    default: {
-      http: ['https://testnet.rpc.zora.co'],
-    },
-    public: {
-      http: ['https://testnet.rpc.zora.co'],
-    },
-  },
-  blockExplorers: {
-    etherscan: {
-      name: 'Zora Testnet explorer',
-      url: 'https://testnet.explorer.zora.co',
-    },
-    default: {
-      name: 'Zora Testnet explorer',
-      url: 'https://testnet.explorer.zora.co',
-    },
-  },
-} as const satisfies Chain
-
-
-export const base = {
-  id: 8453,
-  name: 'Base',
-  network: 'base',
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
-  rpcUrls: {
-    default: {
-      http: ['https://developer-access-mainnet.base.org'],
-    },
-    public: {
-      http: ['https://developer-access-mainnet.base.org'],
-    },
-  },
-  blockExplorers: {
-    etherscan: {
-      name: 'Basescan',
-      url: 'https://basescan.org',
-    },
-    default: {
-      name: 'BaseScan',
-      url: 'https://basescan.org',
-    },
-  },
-} as const satisfies Chain
-
 export const arbitrumNova = {
   id: 42170,
   name: 'Arbitrum Nova',
@@ -109,38 +33,6 @@ export const arbitrumNova = {
   },
 } as const satisfies Chain
 
-export const linea = {
-  id: 59144,
-  name: 'Linea',
-  network: 'linea',
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
-  rpcUrls: {
-    default: {
-      http: ['https://rpc.linea.build'],
-    },
-    public: {
-      http: ['https://rpc.linea.build'],
-    },
-    infura: {
-      http: ['https://linea-mainnet.infura.io/v3']
-    }
-  },
-  blockExplorers: {
-    etherscan: {
-      name: 'Linea Explorer',
-      url: 'https://explorer.linea.build',
-    },
-    default: {
-      name: 'Linea Explorer',
-      url: 'https://explorer.linea.build',
-    },
-  },
-} as const satisfies Chain
-
 export const customChains = {
-  zora,
-  zoraTestnet,
-  base,
   arbitrumNova,
-  linea
 } as const satisfies Record<string, Chain>

--- a/packages/ui/src/context/CartProvider.tsx
+++ b/packages/ui/src/context/CartProvider.tsx
@@ -12,7 +12,7 @@ import {
   useReservoirClient,
   useTokens,
 } from '../hooks'
-import { getChainCurrency } from '../hooks/useChainCurrency'
+import { useChainCurrency } from '../hooks/index'
 import { defaultFetcher } from '../lib/swr'
 import React, {
   createContext,
@@ -302,7 +302,7 @@ function cartStore({
         }
       }
       if (currencies.size > 1) {
-        const chainCurrency = getChainCurrency(chains, chainId)
+        const chainCurrency = useChainCurrency(chainId)
         return {
           ...chainCurrency,
           contract: chainCurrency.address,
@@ -1005,10 +1005,7 @@ function cartStore({
       if (!tokens || tokens.length === 0) {
         throw 'Cart is empty'
       }
-      const chainCurrency = getChainCurrency(
-        chains,
-        cartData.current.chain?.id || 1
-      )
+      const chainCurrency = useChainCurrency(cartData.current.chain?.id || 1)
       const currencyChain = client.chains.find(
         (chain) => (chainCurrency.chainId = chain.id)
       )

--- a/packages/ui/src/hooks/useChainCurrency.ts
+++ b/packages/ui/src/hooks/useChainCurrency.ts
@@ -1,26 +1,22 @@
 import { getClient } from '@reservoir0x/reservoir-sdk'
 import { zeroAddress } from 'viem'
-import { Address, Chain, useNetwork } from 'wagmi'
-import { mainnet, goerli } from 'wagmi/chains'
+import { Address } from 'wagmi'
+import * as allChains from 'viem/chains'
 
-export default function (chainId?: number) {
-  const { chains } = useNetwork()
-  return getChainCurrency(chains, chainId)
-}
-
-export const getChainCurrency = (chains: Chain[], chainId?: number) => {
+export default (chainId?: number) => {
   const client = getClient()
   const reservoirChain = chainId
     ? client.chains.find((chain) => chain.id === chainId)
     : client.currentChain()
 
+  const chains = Object.values(allChains)
   let chain = chains.find((chain) => reservoirChain?.id === chain.id)
 
   if (!chain && chains.length > 0) {
     chain = chains[0]
   }
 
-  const ETHChains: number[] = [mainnet.id, goerli.id]
+  const ETHChains: number[] = [allChains.mainnet.id, allChains.goerli.id]
 
   if (!chain || !chain.nativeCurrency || ETHChains.includes(chain.id)) {
     return {
@@ -28,7 +24,7 @@ export const getChainCurrency = (chains: Chain[], chainId?: number) => {
       symbol: 'ETH',
       decimals: 18,
       address: zeroAddress as Address,
-      chainId: chain?.id || mainnet.id,
+      chainId: chain?.id || allChains.mainnet.id,
     }
   } else {
     return {

--- a/packages/ui/src/hooks/useOnChainRoyalties.ts
+++ b/packages/ui/src/hooks/useOnChainRoyalties.ts
@@ -1,6 +1,6 @@
 import { useContractRead } from 'wagmi'
 import { mainnet, goerli } from 'wagmi/chains'
-import useChainCurrency from '../hooks/useChainCurrency'
+import { useChainCurrency } from '../hooks/index'
 import { parseUnits } from 'viem'
 
 type Props = {

--- a/packages/ui/src/modal/acceptBid/AcceptBidModal.tsx
+++ b/packages/ui/src/modal/acceptBid/AcceptBidModal.tsx
@@ -38,7 +38,6 @@ import { Collapsible } from '../../primitives/Collapsible'
 import { ApproveBidCollapsible } from './ApproveBidCollapsible'
 import SigninStep from '../SigninStep'
 import AcceptBidSummaryLineItem from './AcceptBidSummaryLineItem'
-import { useNetwork, useSwitchNetwork } from 'wagmi'
 
 type BidData = {
   tokens?: EnhancedAcceptBidTokenData[]
@@ -90,25 +89,14 @@ export function AcceptBidModal({
 
   const copy: typeof ModalCopy = { ...ModalCopy, ...copyOverrides }
 
-  const { chain: activeWalletChain } = useNetwork()
   const client = useReservoirClient()
-  const { switchNetworkAsync } = useSwitchNetwork()
 
   const currentChain = client?.currentChain()
+  const baseApiUrl = currentChain?.baseApiUrl
 
   const modalChain = chainId
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
-
-  const baseApiUrl = modalChain?.baseApiUrl
-
-  const handleAcceptBid = async (acceptBid: () => void): Promise<void> => {
-    if (modalChain?.id !== activeWalletChain?.id) {
-      const chain = await switchNetworkAsync?.(modalChain?.id)
-      if (chain?.id !== modalChain?.id) return
-    }
-    acceptBid()
-  }
 
   return (
     <AcceptBidModalRenderer
@@ -424,7 +412,7 @@ export function AcceptBidModal({
                     m: '$4',
                   }}
                   color="primary"
-                  onClick={() => handleAcceptBid(acceptBid)}
+                  onClick={acceptBid}
                 >
                   {copy.ctaAccept}
                 </Button>

--- a/packages/ui/src/modal/acceptBid/AcceptBidModalRenderer.tsx
+++ b/packages/ui/src/modal/acceptBid/AcceptBidModalRenderer.tsx
@@ -7,7 +7,7 @@ import React, {
   useMemo,
 } from 'react'
 import { useTokens, useCoinConversion, useReservoirClient } from '../../hooks'
-import { useAccount, useWalletClient, useNetwork } from 'wagmi'
+import { useAccount, useWalletClient } from 'wagmi'
 import {
   Execute,
   ExpectedPrice,
@@ -16,7 +16,9 @@ import {
 } from '@reservoir0x/reservoir-sdk'
 import { Currency } from '../../types/Currency'
 import { parseUnits } from 'viem'
-import { getNetwork } from 'wagmi/actions'
+import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { customChains } from '@reservoir0x/reservoir-sdk'
+import * as allChains from 'viem/chains'
 
 export enum AcceptBidStep {
   Checkout,
@@ -83,7 +85,6 @@ export const AcceptBidModalRenderer: FC<Props> = ({
   normalizeRoyalties,
   children,
 }) => {
-  const { data: wallet } = useWalletClient()
   const [stepData, setStepData] = useState<AcceptBidStepData | null>(null)
   const [prices, setPrices] = useState<AcceptBidPrice[]>([])
   const [acceptBidStep, setAcceptBidStep] = useState<AcceptBidStep>(
@@ -91,17 +92,20 @@ export const AcceptBidModalRenderer: FC<Props> = ({
   )
   const [transactionError, setTransactionError] = useState<Error | null>()
   const [txHash, setTxHash] = useState<string | null>(null)
-  const { chains } = useNetwork()
 
   const client = useReservoirClient()
-
   const currentChain = client?.currentChain()
 
   const rendererChain = chainId
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
 
-  const wagmiChain = chains.find(({ id }) => rendererChain?.id === id)
+  const wagmiChain: allChains.Chain | undefined = Object.values({
+    ...allChains,
+    ...customChains,
+  }).find(({ id }) => rendererChain?.id === id)
+  
+  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
 
   const blockExplorerBaseUrl =
     wagmiChain?.blockExplorers?.etherscan?.url || 'https://etherscan.io'
@@ -286,7 +290,7 @@ export const AcceptBidModalRenderer: FC<Props> = ({
     [conversions]
   )
 
-  const acceptBid = useCallback(() => {
+  const acceptBid = useCallback(async () => {
     setTransactionError(null)
     if (!wallet) {
       const error = new Error('Missing a wallet/signer')
@@ -294,7 +298,14 @@ export const AcceptBidModalRenderer: FC<Props> = ({
       throw error
     }
 
-    if (rendererChain?.id !== getNetwork()?.chain?.id) {
+    let activeWalletChain = getNetwork().chain
+    if (activeWalletChain && rendererChain?.id !== activeWalletChain?.id) {
+      activeWalletChain = await switchNetwork({
+        chainId: rendererChain?.id as number,
+      })
+    }
+
+    if (rendererChain?.id !== activeWalletChain?.id) {
       const error = new Error(`Mismatching chainIds`)
       setTransactionError(error)
       throw error

--- a/packages/ui/src/modal/bid/BidModal.tsx
+++ b/packages/ui/src/modal/bid/BidModal.tsx
@@ -55,7 +55,6 @@ import { CurrencySelector } from '../CurrencySelector'
 import { ProviderOptionsContext } from '../../ReservoirKitProvider'
 import { CSS } from '@stitches/react'
 import QuantitySelector from '../QuantitySelector'
-import { useNetwork, useSwitchNetwork } from 'wagmi'
 
 type BidCallbackData = {
   tokenId?: string
@@ -159,8 +158,6 @@ export function BidModal({
   )
 
   const client = useReservoirClient()
-  const { chain: activeWalletChain } = useNetwork()
-  const { switchNetworkAsync } = useSwitchNetwork()
 
   const currentChain = client?.currentChain()
 
@@ -174,14 +171,6 @@ export function BidModal({
     typeof getLocalMarketplaceData
   > | null>(null)
   const [attributesSelectable, setAttributesSelectable] = useState(false)
-
-  const handlePlaceBid = async (placeBid: () => void): Promise<void> => {
-    if (modalChain?.id !== activeWalletChain?.id) {
-      const chain = await switchNetworkAsync?.(modalChain?.id)
-      if (chain?.id !== modalChain?.id) return
-    }
-    placeBid()
-  }
 
   useEffect(() => {
     setLocalMarketplace(getLocalMarketplaceData())
@@ -738,7 +727,7 @@ export function BidModal({
                     )}
                     {bidAmountPerUnit !== '' && hasEnoughWrappedCurrency && (
                       <Button
-                        onClick={() => handlePlaceBid(placeBid)}
+                        onClick={() => placeBid()}
                         css={{ width: '100%' }}
                       >
                         {copy.ctaBid.length > 0

--- a/packages/ui/src/modal/buy/BuyModal.tsx
+++ b/packages/ui/src/modal/buy/BuyModal.tsx
@@ -21,7 +21,6 @@ import TokenLineItem from '../TokenLineItem'
 import { BuyModalRenderer, BuyStep, BuyModalStepData } from './BuyModalRenderer'
 import { Execute } from '@reservoir0x/reservoir-sdk'
 import ProgressBar from '../ProgressBar'
-import { useNetwork, useSwitchNetwork } from 'wagmi'
 import QuantitySelector from '../QuantitySelector'
 import { formatNumber } from '../../lib/numbers'
 
@@ -38,6 +37,7 @@ const ModalCopy = {
   titleDefault: 'Complete Checkout',
   ctaClose: 'Close',
   ctaCheckout: 'Checkout',
+  ctaConnect: 'Connect',
   ctaInsufficientFunds: 'Add Funds',
   ctaGoToToken: '',
   ctaAwaitingValidation: 'Waiting for transaction to be validated',
@@ -55,6 +55,7 @@ type Props = Pick<Parameters<typeof Modal>['0'], 'trigger'> & {
   feesOnTopUsd?: string[] | null
   normalizeRoyalties?: boolean
   copyOverrides?: Partial<typeof ModalCopy>
+  onConnectWallet: () => void
   onGoToToken?: () => any
   onPurchaseComplete?: (data: PurchaseData) => void
   onPurchaseError?: (error: Error, data: PurchaseData) => void
@@ -68,7 +69,8 @@ type Props = Pick<Parameters<typeof Modal>['0'], 'trigger'> & {
 function titleForStep(
   step: BuyStep,
   copy: typeof ModalCopy,
-  isLoading: boolean
+  isLoading: boolean,
+  isOwner: boolean
 ) {
   if (isLoading) {
     return copy.titleDefault
@@ -76,7 +78,7 @@ function titleForStep(
 
   switch (step) {
     case BuyStep.Unavailable:
-      return copy.titleUnavilable
+      return isOwner ? 'You already own this token' : copy.titleUnavilable
     default:
       return copy.titleDefault
   }
@@ -93,6 +95,7 @@ export function BuyModal({
   feesOnTopUsd,
   normalizeRoyalties,
   copyOverrides,
+  onConnectWallet,
   onPurchaseComplete,
   onPurchaseError,
   onClose,
@@ -104,25 +107,13 @@ export function BuyModal({
     openState
   )
 
-  const { chains, chain: activeWalletChain } = useNetwork()
   const client = useReservoirClient()
-  const { switchNetworkAsync } = useSwitchNetwork()
 
   const currentChain = client?.currentChain()
 
   const modalChain = chainId
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
-
-  const wagmiChain = chains.find(({ id }) => modalChain?.id === id)
-
-  const handleBuy = async (buyToken: () => void): Promise<void> => {
-    if (modalChain?.id !== activeWalletChain?.id) {
-      const chain = await switchNetworkAsync?.(modalChain?.id)
-      if (chain?.id !== modalChain?.id) return
-    }
-    buyToken()
-  }
 
   return (
     <BuyModalRenderer
@@ -134,6 +125,7 @@ export function BuyModal({
       feesOnTopBps={feesOnTopBps}
       feesOnTopUsd={feesOnTopUsd}
       normalizeRoyalties={normalizeRoyalties}
+      onConnectWallet={onConnectWallet}
     >
       {({
         loading,
@@ -159,11 +151,14 @@ export function BuyModal({
         balance,
         address,
         blockExplorerBaseUrl,
+        blockExplorerBaseName,
+        isConnected,
+        isOwner,
         setQuantity,
         setBuyStep,
         buyToken,
       }) => {
-        const title = titleForStep(buyStep, copy, loading)
+        const title = titleForStep(buyStep, copy, loading, isOwner)
 
         useEffect(() => {
           if (buyStep === BuyStep.Complete && onPurchaseComplete) {
@@ -215,6 +210,18 @@ export function BuyModal({
             trigger={trigger}
             title={title}
             open={open}
+            onPointerDownOutside={(e) => {
+              const dismissableLayers = Array.from(
+                document.querySelectorAll('div[data-radix-dismissable]')
+              )
+              const clickedDismissableLayer = dismissableLayers.some((el) =>
+                e.target ? el.contains(e.target as Node) : false
+              )
+
+              if (!clickedDismissableLayer && dismissableLayers.length > 0) {
+                e.preventDefault()
+              }
+            }}
             onOpenChange={(open) => {
               if (!open && onClose) {
                 const data: PurchaseData = {
@@ -377,13 +384,13 @@ export function BuyModal({
                 </Flex>
 
                 <Box css={{ p: '$4', width: '100%' }}>
-                  {hasEnoughCurrency ? (
+                  {hasEnoughCurrency || !isConnected ? (
                     <Button
-                      onClick={() => handleBuy(buyToken)}
+                      onClick={buyToken}
                       css={{ width: '100%' }}
                       color="primary"
                     >
-                      {copy.ctaCheckout}
+                      {!isConnected ? copy.ctaConnect : copy.ctaCheckout}
                     </Button>
                   ) : (
                     <Flex direction="column" align="center">
@@ -577,9 +584,7 @@ export function BuyModal({
                         href={`${blockExplorerBaseUrl}/tx/${finalTxHash}`}
                         target="_blank"
                       >
-                        View on{' '}
-                        {wagmiChain?.blockExplorers?.default.name ||
-                          'Etherscan'}
+                        View on {blockExplorerBaseName}
                       </Anchor>
                     </>
                   )}

--- a/packages/ui/src/modal/buy/BuyModal.tsx
+++ b/packages/ui/src/modal/buy/BuyModal.tsx
@@ -387,6 +387,7 @@ export function BuyModal({
                 <Box css={{ p: '$4', width: '100%' }}>
                   {hasEnoughCurrency || !isConnected ? (
                     <Button
+                      disabled={!hasEnoughCurrency && isConnected}
                       onClick={buyToken}
                       css={{ width: '100%' }}
                       color="primary"

--- a/packages/ui/src/modal/buy/BuyModal.tsx
+++ b/packages/ui/src/modal/buy/BuyModal.tsx
@@ -34,6 +34,7 @@ type PurchaseData = {
 const ModalCopy = {
   titleInsufficientFunds: 'Add Funds',
   titleUnavilable: 'Selected item is no longer Available',
+  titleIsOwner: 'You already own this token',
   titleDefault: 'Complete Checkout',
   ctaClose: 'Close',
   ctaCheckout: 'Checkout',
@@ -78,7 +79,7 @@ function titleForStep(
 
   switch (step) {
     case BuyStep.Unavailable:
-      return isOwner ? 'You already own this token' : copy.titleUnavilable
+      return isOwner ? copy.titleIsOwner : copy.titleUnavilable
     default:
       return copy.titleDefault
   }

--- a/packages/ui/src/modal/buy/BuyModalRenderer.tsx
+++ b/packages/ui/src/modal/buy/BuyModalRenderer.tsx
@@ -142,7 +142,7 @@ export const BuyModalRenderer: FC<Props> = ({
     ...customChains,
   }).find(({ id }) => rendererChain?.id === id)
 
-  const { data: wallet } = useWalletClient()
+  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
 
   const chainCurrency = useChainCurrency(rendererChain?.id)
   const blockExplorerBaseUrl =

--- a/packages/ui/src/modal/cancelBid/CancelBidModalRenderer.tsx
+++ b/packages/ui/src/modal/cancelBid/CancelBidModalRenderer.tsx
@@ -1,8 +1,10 @@
 import React, { FC, useEffect, useState, useCallback, ReactNode } from 'react'
 import { useCoinConversion, useReservoirClient, useBids } from '../../hooks'
-import { useWalletClient, useNetwork } from 'wagmi'
+import { useWalletClient } from 'wagmi'
 import { Execute } from '@reservoir0x/reservoir-sdk'
-import { getNetwork } from 'wagmi/actions'
+import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { customChains } from '@reservoir0x/reservoir-sdk'
+import * as allChains from 'viem/chains'
 
 export enum CancelStep {
   Cancel,
@@ -26,6 +28,7 @@ type ChildrenProps = {
   totalUsd: number
   usdPrice: number
   blockExplorerBaseUrl: string
+  blockExplorerName: string
   steps: Execute['steps'] | null
   stepData: CancelBidStepData | null
   setCancelStep: React.Dispatch<React.SetStateAction<CancelStep>>
@@ -52,20 +55,25 @@ export const CancelBidModalRenderer: FC<Props> = ({
   const [stepData, setStepData] = useState<CancelBidStepData | null>(null)
   const [steps, setSteps] = useState<Execute['steps'] | null>(null)
 
-  const { chains } = useNetwork()
   const client = useReservoirClient()
-
   const currentChain = client?.currentChain()
 
   const rendererChain = chainId
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
 
-  const wagmiChain = chains.find(({ id }) => rendererChain?.id === id)
+  const wagmiChain: allChains.Chain | undefined = Object.values({
+    ...allChains,
+    ...customChains,
+  }).find(({ id }) => rendererChain?.id === id)
+
   const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
 
   const blockExplorerBaseUrl =
     wagmiChain?.blockExplorers?.default.url || 'https://etherscan.io'
+
+  const blockExplorerName =
+    wagmiChain?.blockExplorers?.default?.name || 'Etherscan'
 
   const { data: bids, isFetchingPage } = useBids(
     {
@@ -91,14 +99,21 @@ export const CancelBidModalRenderer: FC<Props> = ({
   const usdPrice = coinConversion.length > 0 ? coinConversion[0].price : 0
   const totalUsd = usdPrice * (bid?.price?.amount?.decimal || 0)
 
-  const cancelOrder = useCallback(() => {
+  const cancelOrder = useCallback(async () => {
     if (!wallet) {
       const error = new Error('Missing a wallet/signer')
       setTransactionError(error)
       throw error
     }
 
-    if (rendererChain?.id !== getNetwork().chain?.id) {
+    let activeWalletChain = getNetwork().chain
+    if (activeWalletChain && rendererChain?.id !== activeWalletChain?.id) {
+      activeWalletChain = await switchNetwork({
+        chainId: rendererChain?.id as number,
+      })
+    }
+
+    if (rendererChain?.id !== activeWalletChain?.id) {
       const error = new Error(`Mismatching chainIds`)
       setTransactionError(error)
       throw error
@@ -212,6 +227,7 @@ export const CancelBidModalRenderer: FC<Props> = ({
         transactionError,
         usdPrice,
         totalUsd,
+        blockExplorerName,
         blockExplorerBaseUrl,
         steps,
         stepData,

--- a/packages/ui/src/modal/cancelListing/CancelListingModal.tsx
+++ b/packages/ui/src/modal/cancelListing/CancelListingModal.tsx
@@ -8,7 +8,6 @@ import {
 import { Modal } from '../Modal'
 import TokenPrimitive from '../TokenPrimitive'
 import Progress from '../Progress'
-import { useNetwork, useSwitchNetwork } from 'wagmi'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faCircleExclamation,
@@ -51,27 +50,13 @@ export function CancelListingModal({
     openState
   )
 
-  const { chains, chain: activeWalletChain } = useNetwork()
   const client = useReservoirClient()
-  const { switchNetworkAsync } = useSwitchNetwork()
 
   const currentChain = client?.currentChain()
 
   const modalChain = chainId
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
-
-  const wagmiChain = chains.find(({ id }) => modalChain?.id === id)
-
-  const handleCancelListing = async (
-    cancelOrder: () => void
-  ): Promise<void> => {
-    if (modalChain?.id !== activeWalletChain?.id) {
-      const chain = await switchNetworkAsync?.(modalChain?.id)
-      if (chain?.id !== modalChain?.id) return
-    }
-    cancelOrder()
-  }
 
   return (
     <CancelListingModalRenderer
@@ -89,6 +74,7 @@ export function CancelListingModal({
         transactionError,
         stepData,
         totalUsd,
+        blockExplorerName,
         blockExplorerBaseUrl,
         cancelOrder,
       }) => {
@@ -198,10 +184,7 @@ export function CancelListingModal({
                     ? 'This action will cancel your listing. You will be prompted to confirm this cancellation from your wallet. A gas fee is required.'
                     : 'This will cancel your listing for free. You will be prompted to confirm this cancellation from your wallet.'}
                 </Text>
-                <Button
-                  onClick={() => handleCancelListing(cancelOrder)}
-                  css={{ m: '$4' }}
-                >
+                <Button onClick={cancelOrder} css={{ m: '$4' }}>
                   {!isOracleOrder && (
                     <FontAwesomeIcon icon={faGasPump} width="16" height="16" />
                   )}
@@ -285,8 +268,7 @@ export function CancelListingModal({
                     href={`${blockExplorerBaseUrl}/tx/${stepData?.currentStepItem.txHash}`}
                     target="_blank"
                   >
-                    View on{' '}
-                    {wagmiChain?.blockExplorers?.default.name || 'Etherscan'}
+                    View on {blockExplorerName}
                   </Anchor>
                 </Flex>
                 <Button

--- a/packages/ui/src/modal/collect/CollectModalRenderer.tsx
+++ b/packages/ui/src/modal/collect/CollectModalRenderer.tsx
@@ -287,8 +287,10 @@ export const CollectModalRenderer: FC<Props> = ({
 
         setContentMode(intendedContentMode)
       })
-      .catch(() => {
+      .catch((err) => {
         setContentMode(mode === 'mint' ? 'mint' : 'sweep')
+        setOrders([])
+        throw err
       })
       .finally(() => {
         setFetchedInitialOrders(true)

--- a/packages/ui/src/modal/collect/CollectModalRenderer.tsx
+++ b/packages/ui/src/modal/collect/CollectModalRenderer.tsx
@@ -6,11 +6,12 @@ import {
   useReservoirClient,
   useTokens,
 } from '../../hooks'
-import { useAccount, useBalance, useNetwork, useWalletClient } from 'wagmi'
+import { useAccount, useBalance, useWalletClient } from 'wagmi'
 import Token from '../list/Token'
 import {
   BuyPath,
   Execute,
+  LogLevel,
   ReservoirChain,
   ReservoirClientActions,
 } from '@reservoir0x/reservoir-sdk'
@@ -18,7 +19,9 @@ import { toFixed } from '../../lib/numbers'
 import { UseBalanceToken } from '../../types/wagmi'
 import { Address, formatUnits, parseUnits, zeroAddress } from 'viem'
 import { BuyResponses } from '@reservoir0x/reservoir-sdk/src/types'
-import { getNetwork } from 'wagmi/actions'
+import { getNetwork, switchNetwork } from 'wagmi/actions'
+import * as allChains from 'viem/chains'
+import { customChains } from '@reservoir0x/reservoir-sdk'
 
 export enum CollectStep {
   Idle,
@@ -74,6 +77,7 @@ export type ChildrenProps = {
   currentChain: ReservoirChain | null | undefined
   address?: string
   balance?: bigint
+  isConnected: boolean
   contract: Address
   hasEnoughCurrency: boolean
   addFundsLink: string
@@ -91,6 +95,7 @@ type Props = {
   mode?: CollectModalMode
   collectionId?: string
   tokenId?: string
+  onConnectWallet: () => void
   chainId?: number
   feesOnTopBps?: string[] | null
   feesOnTopUsd?: string[] | null
@@ -106,10 +111,11 @@ export const CollectModalRenderer: FC<Props> = ({
   tokenId,
   feesOnTopBps,
   feesOnTopUsd,
+  onConnectWallet,
   normalizeRoyalties,
   children,
 }) => {
-  const account = useAccount()
+  const { address } = useAccount()
   const [selectedTokens, setSelectedTokens] = useState<NonNullable<BuyPath>>([])
   const [fetchedInitialOrders, setFetchedInitialOrders] = useState(false)
   const [orders, setOrders] = useState<NonNullable<BuyPath>>([])
@@ -147,7 +153,6 @@ export const CollectModalRenderer: FC<Props> = ({
 
   const contract = collectionId?.split(':')[0] as Address
 
-  const { chains } = useNetwork()
   const client = useReservoirClient()
 
   const currentChain = client?.currentChain()
@@ -156,7 +161,11 @@ export const CollectModalRenderer: FC<Props> = ({
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
 
-  const wagmiChain = chains.find(({ id }) => rendererChain?.id === id)
+  const wagmiChain: allChains.Chain | undefined = Object.values({
+    ...allChains,
+    ...customChains,
+  }).find(({ id }) => rendererChain?.id === id)
+
   const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
 
   const blockExplorerBaseUrl =
@@ -203,7 +212,7 @@ export const CollectModalRenderer: FC<Props> = ({
   const totalUsd = usdPrice * (totalIncludingFees || 0)
 
   const fetchBuyPath = useCallback(() => {
-    if (!wallet || !client) {
+    if (!client) {
       return
     }
 
@@ -230,7 +239,11 @@ export const CollectModalRenderer: FC<Props> = ({
         ],
         expectedPrice: undefined,
         options,
-        wallet,
+        wallet: {
+          address: async () => {
+            return address || zeroAddress
+          },
+        } as any,
         precheck: true,
         onProgress: () => {},
       })
@@ -281,6 +294,7 @@ export const CollectModalRenderer: FC<Props> = ({
         setFetchedInitialOrders(true)
       })
   }, [
+    address,
     client,
     wallet,
     rendererChain,
@@ -457,7 +471,7 @@ export const CollectModalRenderer: FC<Props> = ({
 
   const { data: balance } = useBalance({
     chainId: wagmiChain?.id,
-    address: account.address,
+    address: address,
     token:
       currency?.address !== zeroAddress
         ? (currency?.address as UseBalanceToken)
@@ -517,21 +531,30 @@ export const CollectModalRenderer: FC<Props> = ({
     }
   }, [open])
 
-  const collectTokens = useCallback(() => {
+  const collectTokens = useCallback(async () => {
     if (!wallet) {
-      const error = new Error('Missing a wallet/signer')
+      onConnectWallet()
+      if (document.body.style) {
+        document.body.style.pointerEvents = 'auto'
+      }
+      client?.log(['Missing wallet, prompting connection'], LogLevel.Verbose)
+      return
+    }
+
+    let activeWalletChain = getNetwork().chain
+    if (activeWalletChain && rendererChain?.id !== activeWalletChain?.id) {
+      activeWalletChain = await switchNetwork({
+        chainId: rendererChain?.id as number,
+      })
+    }
+    if (rendererChain?.id !== activeWalletChain?.id) {
+      const error = new Error(`Mismatching chainIds`)
       setTransactionError(error)
       throw error
     }
 
     if (!client) {
       const error = new Error('ReservoirClient was not initialized')
-      setTransactionError(error)
-      throw error
-    }
-
-    if (rendererChain?.id !== getNetwork()?.chain?.id) {
-      const error = new Error('Mismatching chainIds')
       setTransactionError(error)
       throw error
     }
@@ -674,6 +697,7 @@ export const CollectModalRenderer: FC<Props> = ({
     selectedTokens,
     client,
     wallet,
+    address,
     total,
     normalizeRoyalties,
     wagmiChain,
@@ -682,6 +706,7 @@ export const CollectModalRenderer: FC<Props> = ({
     tokenId,
     currency,
     feesOnTopBps,
+    onConnectWallet,
     feesOnTopUsd,
     contentMode,
     itemAmount,
@@ -694,7 +719,7 @@ export const CollectModalRenderer: FC<Props> = ({
         collection,
         token,
         loading: !fetchedInitialOrders,
-        address: account?.address,
+        address: address,
         selectedTokens,
         setSelectedTokens,
         itemAmount,
@@ -710,6 +735,7 @@ export const CollectModalRenderer: FC<Props> = ({
         feeOnTop,
         feeUsd,
         usdPrice,
+        isConnected: wallet !== undefined,
         currentChain,
         mintPrice,
         orders,

--- a/packages/ui/src/modal/collect/mint/MintContent.tsx
+++ b/packages/ui/src/modal/collect/mint/MintContent.tsx
@@ -61,6 +61,7 @@ export const MintContent: FC<
   transactionError,
   stepData,
   collectStep,
+  isConnected,
   collectTokens,
   copy,
   setOpen,
@@ -239,13 +240,13 @@ export const MintContent: FC<
                 </Flex>
               </Flex>
             </Flex>
-            {hasEnoughCurrency ? (
+            {hasEnoughCurrency || !isConnected ? (
               <Button
                 css={{ m: '$4' }}
                 disabled={!hasEnoughCurrency}
                 onClick={collectTokens}
               >
-                {copy.mintCtaBuy}
+                {!isConnected ? copy.ctaConnect : copy.mintCtaBuy}
               </Button>
             ) : (
               <Flex

--- a/packages/ui/src/modal/collect/sweep/SweepContent.tsx
+++ b/packages/ui/src/modal/collect/sweep/SweepContent.tsx
@@ -51,6 +51,7 @@ export const SweepContent: FC<
   totalUsd,
   feeOnTop,
   feeUsd,
+  isConnected,
   usdPrice,
   currentChain,
   balance,
@@ -260,13 +261,18 @@ export const SweepContent: FC<
               </Flex>
             </Flex>
           </Flex>
-          {hasEnoughCurrency ? (
+          {hasEnoughCurrency || !isConnected ? (
             <Button
               css={{ m: '$4' }}
-              disabled={!(selectedTokens.length > 0) || !hasEnoughCurrency}
+              disabled={
+                !(selectedTokens.length > 0) ||
+                (!hasEnoughCurrency && isConnected)
+              }
               onClick={collectTokens}
             >
-              {selectedTokens.length > 0
+              {!isConnected
+                ? copy.ctaConnect
+                : selectedTokens.length > 0
                 ? copy.sweepCtaBuy
                 : copy.sweepCtaBuyDisabled}
             </Button>

--- a/packages/ui/src/modal/editBid/EditBidModal.tsx
+++ b/packages/ui/src/modal/editBid/EditBidModal.tsx
@@ -33,7 +33,6 @@ import {
   faCircleExclamation,
   faClose,
 } from '@fortawesome/free-solid-svg-icons'
-import { useSwitchNetwork, useNetwork } from 'wagmi'
 const ModalCopy = {
   title: 'Edit Offer',
   ctaClose: 'Close',
@@ -77,23 +76,13 @@ export function EditBidModal({
     openState
   )
 
-  const { chain: activeWalletChain } = useNetwork()
   const client = useReservoirClient()
-  const { switchNetworkAsync } = useSwitchNetwork()
 
   const currentChain = client?.currentChain()
 
   const modalChain = chainId
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
-
-  const handleEditBid = async (editBid: () => void): Promise<void> => {
-    if (modalChain?.id !== activeWalletChain?.id) {
-      const chain = await switchNetworkAsync?.(modalChain?.id)
-      if (chain?.id !== modalChain?.id) return
-    }
-    editBid()
-  }
 
   return (
     <EditBidModalRenderer
@@ -496,7 +485,7 @@ export function EditBidModal({
                         </Button>
                         <Button
                           disabled={bidAmount === '' || bidAmount === '0'}
-                          onClick={() => handleEditBid(editBid)}
+                          onClick={editBid}
                           css={{ flex: 1 }}
                         >
                           {copy.ctaConfirm}

--- a/packages/ui/src/modal/editListing/EditListingModal.tsx
+++ b/packages/ui/src/modal/editListing/EditListingModal.tsx
@@ -16,7 +16,6 @@ import {
 import PriceInput from './PriceInput'
 import InfoTooltip from '../../primitives/InfoTooltip'
 import { zeroAddress } from 'viem'
-import { useSwitchNetwork, useNetwork } from 'wagmi'
 
 const ModalCopy = {
   title: 'Edit Listing',
@@ -63,24 +62,13 @@ export function EditListingModal({
     openState ? openState[0] : false,
     openState
   )
-
-  const { chain: activeWalletChain } = useNetwork()
   const client = useReservoirClient()
-  const { switchNetworkAsync } = useSwitchNetwork()
 
   const currentChain = client?.currentChain()
 
   const modalChain = chainId
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
-
-  const handleEditListing = async (editListing: () => void): Promise<void> => {
-    if (modalChain?.id !== activeWalletChain?.id) {
-      const chain = await switchNetworkAsync?.(modalChain?.id)
-      if (chain?.id !== modalChain?.id) return
-    }
-    editListing()
-  }
 
   return (
     <EditListingModalRenderer
@@ -388,7 +376,7 @@ export function EditListingModal({
                         price === 0 ||
                         price < MINIMUM_AMOUNT
                       }
-                      onClick={() => handleEditListing(editListing)}
+                      onClick={editListing}
                       css={{ flex: 1 }}
                     >
                       {copy.ctaConfirm}

--- a/packages/ui/src/modal/editListing/EditListingModalRenderer.tsx
+++ b/packages/ui/src/modal/editListing/EditListingModalRenderer.tsx
@@ -23,7 +23,7 @@ import expirationOptions from '../../lib/defaultExpirationOptions'
 import dayjs from 'dayjs'
 import { Listings } from '../list/ListModalRenderer'
 import { formatUnits, parseUnits, zeroAddress } from 'viem'
-import { getNetwork } from 'wagmi/actions'
+import { getNetwork, switchNetwork } from 'wagmi/actions'
 
 export enum EditListingStep {
   Edit,
@@ -90,7 +90,6 @@ export const EditListingModalRenderer: FC<Props> = ({
   children,
 }) => {
   const client = useReservoirClient()
-
   const currentChain = client?.currentChain()
 
   const rendererChain = chainId
@@ -219,14 +218,21 @@ export const EditListingModalRenderer: FC<Props> = ({
     royaltyBps = onChainRoyaltyBps
   }
 
-  const editListing = useCallback(() => {
+  const editListing = useCallback(async () => {
     if (!wallet) {
       const error = new Error('Missing a wallet/signer')
       setTransactionError(error)
       throw error
     }
 
-    if (rendererChain?.id !== getNetwork()?.chain?.id) {
+    let activeWalletChain = getNetwork().chain
+    if (activeWalletChain && rendererChain?.id !== activeWalletChain?.id) {
+      activeWalletChain = await switchNetwork({
+        chainId: rendererChain?.id as number,
+      })
+    }
+
+    if (rendererChain?.id !== activeWalletChain?.id) {
       const error = new Error(`Mismatching chainIds`)
       setTransactionError(error)
       throw error

--- a/packages/ui/src/modal/list/ListModal.tsx
+++ b/packages/ui/src/modal/list/ListModal.tsx
@@ -48,7 +48,6 @@ import { CurrencySelector } from '../CurrencySelector'
 import { zeroAddress } from 'viem'
 import { ProviderOptionsContext } from '../../ReservoirKitProvider'
 import { CSS } from '@stitches/react'
-import { useSwitchNetwork, useNetwork } from 'wagmi'
 
 type ListingCallbackData = {
   listings?: ListingData[]
@@ -141,9 +140,7 @@ export function ListModal({
     openState
   )
 
-  const { chain: activeWalletChain } = useNetwork()
   const client = useReservoirClient()
-  const { switchNetworkAsync } = useSwitchNetwork()
 
   const currentChain = client?.currentChain()
 
@@ -159,14 +156,6 @@ export function ListModal({
 
   if (oracleEnabled) {
     nativeOnly = true
-  }
-
-  const handleList = async (listToken: () => void): Promise<void> => {
-    if (modalChain?.id !== activeWalletChain?.id) {
-      const chain = await switchNetworkAsync?.(modalChain?.id)
-      if (chain?.id !== modalChain?.id) return
-    }
-    listToken()
   }
 
   return (
@@ -670,7 +659,7 @@ export function ListModal({
                           marketplace.price == 0 ||
                           Number(marketplace.price) < MINIMUM_AMOUNT
                       )}
-                      onClick={() => handleList(listToken)}
+                      onClick={listToken}
                       css={{ width: '100%' }}
                     >
                       {copy.ctaList}

--- a/packages/ui/src/modal/list/ListModalRenderer.tsx
+++ b/packages/ui/src/modal/list/ListModalRenderer.tsx
@@ -26,7 +26,7 @@ import { ExpirationOption } from '../../types/ExpirationOption'
 import expirationOptions from '../../lib/defaultExpirationOptions'
 import { Currency } from '../../types/Currency'
 import { formatUnits, parseUnits, zeroAddress } from 'viem'
-import { getNetwork } from 'wagmi/actions'
+import { getNetwork, switchNetwork } from 'wagmi/actions'
 
 export enum ListStep {
   SelectMarkets,
@@ -129,7 +129,6 @@ export const ListModalRenderer: FC<Props> = ({
   const account = useAccount()
 
   const client = useReservoirClient()
-
   const currentChain = client?.currentChain()
 
   const rendererChain = chainId
@@ -368,14 +367,21 @@ export const ListModalRenderer: FC<Props> = ({
     }
   }, [currencies])
 
-  const listToken = useCallback(() => {
+  const listToken = useCallback(async () => {
     if (!wallet) {
       const error = new Error('Missing a wallet/signer')
       setTransactionError(error)
       throw error
     }
 
-    if (rendererChain?.id !== getNetwork().chain?.id) {
+    let activeWalletChain = getNetwork().chain
+    if (activeWalletChain && rendererChain?.id !== activeWalletChain?.id) {
+      activeWalletChain = await switchNetwork({
+        chainId: rendererChain?.id as number,
+      })
+    }
+
+    if (rendererChain?.id !== activeWalletChain?.id) {
       const error = new Error(`Mismatching chainIds`)
       setTransactionError(error)
       throw error

--- a/packages/ui/src/primitives/Dialog.tsx
+++ b/packages/ui/src/primitives/Dialog.tsx
@@ -162,7 +162,7 @@ const Dialog = forwardRef<
         <AnimatePresence>
           {dialogOpen && (
             <DialogPrimitive.DialogPortal forceMount {...portalProps}>
-              <AnimatedOverlay />
+              <AnimatedOverlay data-radix-dismissable />
               <StyledAnimatedContent
                 ref={forwardedRef}
                 {...props}


### PR DESCRIPTION
* Clean up custom chains
* Allow opening buymodal without being connected
* Move chain switching logic to inside the renderer to reduce complexity when using a custom buy modal