### PR TITLE
feat: add wallet client optional for all the modals

### DIFF
--- a/packages/ui/src/modal/acceptBid/AcceptBidModalRenderer.tsx
+++ b/packages/ui/src/modal/acceptBid/AcceptBidModalRenderer.tsx
@@ -16,7 +16,7 @@ import {
 } from '@reservoir0x/reservoir-sdk'
 import { Currency } from '../../types/Currency'
 import { parseUnits } from 'viem'
-import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { GetWalletClientResult, getNetwork, switchNetwork } from 'wagmi/actions'
 import { customChains } from '@reservoir0x/reservoir-sdk'
 import * as allChains from 'viem/chains'
 
@@ -76,6 +76,7 @@ type Props = {
   chainId?: number
   normalizeRoyalties?: boolean
   children: (props: ChildrenProps) => ReactNode
+  walletClient?: GetWalletClientResult
 }
 
 export const AcceptBidModalRenderer: FC<Props> = ({
@@ -84,6 +85,7 @@ export const AcceptBidModalRenderer: FC<Props> = ({
   chainId,
   normalizeRoyalties,
   children,
+  walletClient,
 }) => {
   const [stepData, setStepData] = useState<AcceptBidStepData | null>(null)
   const [prices, setPrices] = useState<AcceptBidPrice[]>([])
@@ -104,7 +106,9 @@ export const AcceptBidModalRenderer: FC<Props> = ({
     ...allChains,
     ...customChains,
   }).find(({ id }) => rendererChain?.id === id)
-  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
+  const { data: wagmiWallet } = useWalletClient({ chainId: rendererChain?.id})
+
+  const wallet = walletClient || wagmiWallet;
 
   const blockExplorerBaseUrl =
     wagmiChain?.blockExplorers?.default?.url || 'https://etherscan.io'

--- a/packages/ui/src/modal/bid/BidModalRenderer.tsx
+++ b/packages/ui/src/modal/bid/BidModalRenderer.tsx
@@ -28,7 +28,7 @@ import wrappedContractNames from '../../constants/wrappedContractNames'
 import wrappedContracts from '../../constants/wrappedContracts'
 import { Currency } from '../../types/Currency'
 import { parseUnits } from 'viem'
-import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { GetWalletClientResult, getNetwork, switchNetwork } from 'wagmi/actions'
 import { customChains } from '@reservoir0x/reservoir-sdk'
 import * as allChains from 'viem/chains'
 
@@ -121,6 +121,7 @@ type Props = {
   feesBps?: string[] | null
   orderKind?: BidData['orderKind']
   children: (props: ChildrenProps) => ReactNode
+  walletClient?: GetWalletClientResult
 }
 
 export type BidData = Parameters<
@@ -145,6 +146,7 @@ export const BidModalRenderer: FC<Props> = ({
   oracleEnabled = false,
   feesBps,
   children,
+  walletClient
 }) => {
   const client = useReservoirClient()
   const currentChain = client?.currentChain()
@@ -158,7 +160,9 @@ export const BidModalRenderer: FC<Props> = ({
     ...customChains,
   }).find(({ id }) => rendererChain?.id === id)
 
-  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
+  const { data: wagmiWallet } = useWalletClient({ chainId: rendererChain?.id})
+
+  const wallet = walletClient || wagmiWallet;
 
   const [bidStep, setBidStep] = useState<BidStep>(BidStep.SetPrice)
   const [transactionError, setTransactionError] = useState<Error | null>()

--- a/packages/ui/src/modal/buy/BuyModalRenderer.tsx
+++ b/packages/ui/src/modal/buy/BuyModalRenderer.tsx
@@ -15,7 +15,7 @@ import {
   useCurrencyConversion,
 } from '../../hooks'
 import { useAccount, useBalance, useWalletClient } from 'wagmi'
-import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { GetWalletClientResult, getNetwork, switchNetwork } from 'wagmi/actions'
 
 import {
   BuyPath,
@@ -101,6 +101,7 @@ type Props = {
   normalizeRoyalties?: boolean
   onConnectWallet: () => void
   children: (props: ChildrenProps) => ReactNode
+  walletClient?: GetWalletClientResult
 }
 
 export const BuyModalRenderer: FC<Props> = ({
@@ -114,6 +115,7 @@ export const BuyModalRenderer: FC<Props> = ({
   normalizeRoyalties,
   onConnectWallet,
   children,
+  walletClient
 }) => {
   const [totalPrice, setTotalPrice] = useState(0)
   const [totalIncludingFees, setTotalIncludingFees] = useState(0)
@@ -142,7 +144,9 @@ export const BuyModalRenderer: FC<Props> = ({
     ...customChains,
   }).find(({ id }) => rendererChain?.id === id)
 
-  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
+  const { data: wagmiWalletClient } = useWalletClient({ chainId: rendererChain?.id })
+  
+  const wallet = walletClient || wagmiWalletClient
 
   const chainCurrency = useChainCurrency(rendererChain?.id)
   const blockExplorerBaseUrl =

--- a/packages/ui/src/modal/cancelBid/CancelBidModalRenderer.tsx
+++ b/packages/ui/src/modal/cancelBid/CancelBidModalRenderer.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState, useCallback, ReactNode } from 'react'
 import { useCoinConversion, useReservoirClient, useBids } from '../../hooks'
 import { useWalletClient } from 'wagmi'
 import { Execute } from '@reservoir0x/reservoir-sdk'
-import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { GetWalletClientResult, getNetwork, switchNetwork } from 'wagmi/actions'
 import { customChains } from '@reservoir0x/reservoir-sdk'
 import * as allChains from 'viem/chains'
 
@@ -41,6 +41,7 @@ type Props = {
   chainId?: number
   normalizeRoyalties?: boolean
   children: (props: ChildrenProps) => ReactNode
+  walletClient?: GetWalletClientResult
 }
 
 export const CancelBidModalRenderer: FC<Props> = ({
@@ -49,6 +50,7 @@ export const CancelBidModalRenderer: FC<Props> = ({
   bidId,
   normalizeRoyalties,
   children,
+  walletClient
 }) => {
   const [cancelStep, setCancelStep] = useState<CancelStep>(CancelStep.Cancel)
   const [transactionError, setTransactionError] = useState<Error | null>()
@@ -67,7 +69,9 @@ export const CancelBidModalRenderer: FC<Props> = ({
     ...customChains,
   }).find(({ id }) => rendererChain?.id === id)
 
-  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
+  const { data: wagmiWallet } = useWalletClient({ chainId: rendererChain?.id})
+
+  const wallet = walletClient || wagmiWallet;
 
   const blockExplorerBaseUrl =
     wagmiChain?.blockExplorers?.default.url || 'https://etherscan.io'

--- a/packages/ui/src/modal/cancelListing/CancelListingModalRenderer.tsx
+++ b/packages/ui/src/modal/cancelListing/CancelListingModalRenderer.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState, useCallback, ReactNode } from 'react'
 import { useCoinConversion, useReservoirClient, useListings } from '../../hooks'
 import { useWalletClient } from 'wagmi'
 import { Execute } from '@reservoir0x/reservoir-sdk'
-import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { GetWalletClientResult, getNetwork, switchNetwork } from 'wagmi/actions'
 import { customChains } from '@reservoir0x/reservoir-sdk'
 import * as allChains from 'viem/chains'
 
@@ -42,6 +42,7 @@ type Props = {
   chainId?: number
   normalizeRoyalties?: boolean
   children: (props: ChildrenProps) => ReactNode
+  walletClient?: GetWalletClientResult
 }
 
 export const CancelListingModalRenderer: FC<Props> = ({
@@ -50,6 +51,7 @@ export const CancelListingModalRenderer: FC<Props> = ({
   chainId,
   normalizeRoyalties,
   children,
+  walletClient
 }) => {
   const [cancelStep, setCancelStep] = useState<CancelStep>(CancelStep.Cancel)
   const [transactionError, setTransactionError] = useState<Error | null>()
@@ -68,8 +70,9 @@ export const CancelListingModalRenderer: FC<Props> = ({
     ...customChains,
   }).find(({ id }) => rendererChain?.id === id)
 
-  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
+  const { data: wagmiWallet } = useWalletClient({ chainId: rendererChain?.id})
 
+  const wallet = walletClient || wagmiWallet; 
   const blockExplorerBaseUrl =
     wagmiChain?.blockExplorers?.default.url || 'https://etherscan.io'
 

--- a/packages/ui/src/modal/editBid/EditBidModalRenderer.tsx
+++ b/packages/ui/src/modal/editBid/EditBidModalRenderer.tsx
@@ -26,7 +26,7 @@ import {
 } from '../bid/BidModalRenderer'
 import { formatBN } from '../../lib/numbers'
 import { parseUnits } from 'viem'
-import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { GetWalletClientResult, getNetwork, switchNetwork } from 'wagmi/actions'
 import { customChains } from '@reservoir0x/reservoir-sdk'
 import * as allChains from 'viem/chains'
 
@@ -92,6 +92,7 @@ type Props = {
   collectionId?: string
   normalizeRoyalties?: boolean
   children: (props: ChildrenProps) => ReactNode
+  walletClient?: GetWalletClientResult
 }
 
 export const EditBidModalRenderer: FC<Props> = ({

--- a/packages/ui/src/modal/editListing/EditListingModalRenderer.tsx
+++ b/packages/ui/src/modal/editListing/EditListingModalRenderer.tsx
@@ -23,7 +23,7 @@ import expirationOptions from '../../lib/defaultExpirationOptions'
 import dayjs from 'dayjs'
 import { Listing } from '../list/ListModalRenderer'
 import { formatUnits, parseUnits, zeroAddress } from 'viem'
-import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { GetWalletClientResult, getNetwork, switchNetwork } from 'wagmi/actions'
 
 export enum EditListingStep {
   Edit,
@@ -77,6 +77,7 @@ type Props = {
   normalizeRoyalties?: boolean
   enableOnChainRoyalties: boolean
   children: (props: ChildrenProps) => ReactNode
+  walletClient?: GetWalletClientResult
 }
 
 export const EditListingModalRenderer: FC<Props> = ({
@@ -88,6 +89,7 @@ export const EditListingModalRenderer: FC<Props> = ({
   normalizeRoyalties,
   enableOnChainRoyalties = false,
   children,
+  walletClient
 }) => {
   const client = useReservoirClient()
   const currentChain = client?.currentChain()
@@ -96,7 +98,8 @@ export const EditListingModalRenderer: FC<Props> = ({
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
 
-  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
+  const { data: wagmiWalletClient } = useWalletClient({ chainId: rendererChain?.id })
+  const wallet = walletClient || wagmiWalletClient
   const account = useAccount()
   const [editListingStep, setEditListingStep] = useState<EditListingStep>(
     EditListingStep.Edit

--- a/packages/ui/src/modal/list/ListModalRenderer.tsx
+++ b/packages/ui/src/modal/list/ListModalRenderer.tsx
@@ -24,7 +24,7 @@ import { ExpirationOption } from '../../types/ExpirationOption'
 import defaultExpirationOptions from '../../lib/defaultExpirationOptions'
 import { Currency } from '../../types/Currency'
 import { formatUnits, parseUnits, zeroAddress } from 'viem'
-import { getNetwork, switchNetwork } from 'wagmi/actions'
+import { GetWalletClientResult, getNetwork, switchNetwork } from 'wagmi/actions'
 
 export enum ListStep {
   Unavailable,
@@ -86,7 +86,8 @@ type Props = {
   enableOnChainRoyalties: boolean
   oracleEnabled: boolean
   feesBps?: string[]
-  children: (props: ChildrenProps) => ReactNode
+  children: (props: ChildrenProps) => ReactNode;
+  walletClient?: GetWalletClientResult
 }
 
 const expirationOptions = [
@@ -111,6 +112,7 @@ export const ListModalRenderer: FC<Props> = ({
   oracleEnabled = false,
   feesBps,
   children,
+  walletClient
 }) => {
   const account = useAccount()
 
@@ -121,7 +123,9 @@ export const ListModalRenderer: FC<Props> = ({
     ? client?.chains.find(({ id }) => id === chainId) || currentChain
     : currentChain
 
-  const { data: wallet } = useWalletClient({ chainId: rendererChain?.id })
+  const { data: wagmiWallet } = useWalletClient({ chainId: rendererChain?.id})
+
+  const wallet = walletClient || wagmiWallet;
 
   const [listStep, setListStep] = useState<ListStep>(ListStep.SetPrice)
   const [listingData, setListingData] = useState<ListingData[]>([])


### PR DESCRIPTION
Due to some codebases not being able to migrate fully to `wagmi`, creating a custom client can help during the transition. 

Ive added that so users can override the client!