### PR TITLE
Cart duplicate and key fixes

### DIFF
--- a/packages/ui/src/components/cart/CartPopover.tsx
+++ b/packages/ui/src/components/cart/CartPopover.tsx
@@ -310,7 +310,7 @@ export function CartPopover({
                 >
                   {items.map((item) => (
                     <CartItem
-                      key={`${item.collection.id}:${item.token.id}`}
+                      key={item.order.id}
                       item={item}
                       usdConversion={usdPrice}
                       tokenUrl={tokenUrl}

--- a/packages/ui/src/context/CartProvider.tsx
+++ b/packages/ui/src/context/CartProvider.tsx
@@ -567,17 +567,6 @@ function cartStore({
         const tokens: Token[] = []
         const ordersToFetch: string[] = []
 
-        const tokensByMaker = updatedItems.reduce((map, item) => {
-          if (item.order) {
-            const maker = item.order?.maker
-            if (!map[maker]) {
-              map[maker] = []
-            }
-            map[maker].push(`${item.collection.id}:${item.token.id}`)
-          }
-          return map
-        }, {} as Record<string, string[]>)
-
         items.forEach((item) => {
           const token = item as Token
           const asyncToken = item as AsyncAddToCartToken

--- a/packages/ui/src/context/CartProvider.tsx
+++ b/packages/ui/src/context/CartProvider.tsx
@@ -616,13 +616,9 @@ function cartStore({
               )
               fetchedTokens?.forEach((tokenData) => {
                 const item = convertTokenToItem(tokenData)
-                const id = `${item?.collection.id}:${item?.token.id}`
-                const maker = tokenData.market?.floorAsk?.maker
-                const duplicateListingDetected =
-                  item &&
-                  maker &&
-                  tokensByMaker[maker] &&
-                  tokensByMaker[maker].includes(id)
+                const duplicateListingDetected = updatedItems.some(
+                  (updatedItem) => updatedItem.order.id === item.order.id
+                )
                 if (duplicateListingDetected) {
                   client?.log(
                     [
@@ -651,11 +647,9 @@ function cartStore({
               )
               fetchedOrders?.forEach((orderData) => {
                 const item = convertOrderToItem(orderData)
-                const id = `${item?.collection.id}:${item?.token.id}`
-                const duplicateListingDetected =
-                  item &&
-                  tokensByMaker[orderData.maker] &&
-                  tokensByMaker[orderData.maker].includes(id)
+                const duplicateListingDetected = updatedItems.some(
+                  (updatedItem) => updatedItem.order.id === item.order.id
+                )
                 if (duplicateListingDetected) {
                   client?.log(
                     [


### PR DESCRIPTION
This update simplifies cart management by using order IDs instead of a combination of contract address and token ID, addressing non-unique key errors when adding multiple 1155 orders of the same token. Additionally, the logic for checking duplicate items now focuses on order IDs rather than the order creator, allowing the inclusion of multiple orders from the same user for the same token.

[Here](https://explorer.reservoir.tools/ethereum/asset/0x9b0a422f25a5f26a16b2b3a3eb37a72ae31d3ec3:3?tab=listings) is an example of the current issue, try adding the top 2 listings (both by `0xfa…511e`) to your cart.
