### PR TITLE
Ensure wrappedBalance value is a BigInt when subtracting from bid

### DIFF
--- a/packages/ui/src/modal/bid/BidModalRenderer.tsx
+++ b/packages/ui/src/modal/bid/BidModalRenderer.tsx
@@ -351,7 +351,7 @@ export const BidModalRenderer: FC<Props> = ({
 
       if (!wrappedBalance?.value || wrappedBalance?.value < bid) {
         setHasEnoughWrappedCurrency(false)
-        const wrappedAmount = wrappedBalance?.value || 0n
+        const wrappedAmount = wrappedBalance?.value ? BigInt(wrappedBalance.value) : BigInt(0)
         const amountToWrap = bid - wrappedAmount
         setAmountToWrap(formatBN(amountToWrap, 5))
 


### PR DESCRIPTION
In our custom bid modal implementation this was throwing an uncaught error in our local environment. This update ensures that `wrappedAmount` is always a BigInt when subtracting from (the already converted to BigInt) `bid`.