### PR TITLE
Fix fiat currency conversion display

### DIFF
--- a/packages/ui/src/hooks/useCurrencyConversions.ts
+++ b/packages/ui/src/hooks/useCurrencyConversions.ts
@@ -9,7 +9,7 @@ const fetcher = async (urls: string[]) => {
   const fetches = urls.map(
     (url) =>
       axios(url)
-        .then((r) => JSON.parse(r.data))
+        .then((r) => r.data)
         .catch(() => undefined) // If a fetch fails, return undefined
   )
   const results = await Promise.allSettled(fetches)


### PR DESCRIPTION
Fixed fiat currency conversions not displaying properly due to attempting to parse the already well-formed & deserialized JSON response from the requests in `useCurrencyConversions`. The failed fetch resulted in `SyntaxError: JSON.parse: unexpected character at line 1 column 2 of the JSON data`.

> [!NOTE]
> I would recommend adding some logging to the `catch` callback, but totally up to the Reservoir team!

**Before (check bottom right):**

<img width="379" alt="before" src="https://github.com/reservoirprotocol/reservoir-kit/assets/20056195/c0016cce-7322-4e3c-8516-59b8718ab085">

<img width="380" alt="before-2" src="https://github.com/reservoirprotocol/reservoir-kit/assets/20056195/a87f1267-2d67-455e-833d-68db669d8079">

This issue can also be seen in the screenshot in #573.

**After:**

<img width="382" alt="after" src="https://github.com/reservoirprotocol/reservoir-kit/assets/20056195/113a2fb9-6792-4d12-a552-ffd7ad740684">