### PR TITLE
Added code to process Blur authentication token from request.

### DIFF
--- a/packages/sdk/src/utils/executeSteps.ts
+++ b/packages/sdk/src/utils/executeSteps.ts
@@ -552,7 +552,7 @@ export async function executeSteps(
                         orderIndex: res.data.orderIndex || 0,
                       },
                     ]
-                  }
+                  } else if(res.data.auth) request.data.blurAuth = res.data.auth; 
                   setState([...json?.steps], path, { ...json?.fees })
                 } catch (err) {
                   throw err


### PR DESCRIPTION
When canceling a bid on Blur, the first step requires to sign in to Blur. The code doesn't pass the Blur auth token to the next step and the execution gets stuck and eventually errors out when reaches max retry count.